### PR TITLE
feat/visitas-list-finalizar

### DIFF
--- a/src/app/dashboard/_components/visitador/VisitaDetails.tsx
+++ b/src/app/dashboard/_components/visitador/VisitaDetails.tsx
@@ -22,53 +22,117 @@ const formatDate = (dateString: string) =>
     year: 'numeric',
   })
 
+const getEstadoBadge = (estado: Visita['estado']) => {
+  const badges = {
+    PROGRAMADA: 'bg-blue-100 text-blue-800',
+    'EN CURSO': 'bg-yellow-100 text-yellow-800',
+    COMPLETADA: 'bg-green-100 text-green-800',
+    CANCELADA: 'bg-red-100 text-red-800',
+    REPROGRAMADA: 'bg-purple-100 text-purple-800',
+  }
+  return badges[estado] || 'bg-gray-100 text-gray-800'
+}
+
+const getMotivoText = (motivo: Visita['motivo_visita']) => {
+  const motivos = {
+    MEDICION: 'Medición',
+    'RE-MEDICION': 'Re-medición',
+    REPARACION: 'Reparación',
+    ASESORAMIENTO: 'Asesoramiento',
+    'VISITA INICIAL': 'Visita Inicial',
+  }
+  return motivos[motivo] || motivo
+}
+
 export default function VisitaDetails({
   visita,
   onFinalizarVisita,
 }: VisitaDetailsProps) {
+  // Verificar si se puede finalizar la visita
+  const canFinalize = visita.estado === 'PROGRAMADA' || visita.estado === 'EN CURSO'
+
   return (
     <Card className="mx-auto max-w-3xl border-gray-200 bg-white shadow-lg">
       <CardContent className="space-y-6 p-8">
         <div className="flex items-start justify-between">
-          <div>
-            <h3 className="text-2xl font-bold text-gray-800">
-              Detalles de la Visita
-            </h3>
-            <p className="text-gray-500">
-              Cliente: {visita.obra?.cliente.razon_social}
+          <div className="flex-1">
+            <div className="flex items-center space-x-3">
+              <h3 className="text-2xl font-bold text-gray-800">
+                Detalles de la Visita
+              </h3>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${getEstadoBadge(visita.estado)}`}
+              >
+                {visita.estado}
+              </span>
+            </div>
+            <p className="mt-1 text-gray-500">
+              {visita.obra?.cliente.razon_social || 'Sin obra asignada'}
+            </p>
+            <p className="text-sm text-gray-400">
+              Motivo: {getMotivoText(visita.motivo_visita)}
             </p>
           </div>
           <UserIcon className="h-12 w-12 text-gray-300" />
         </div>
-        <div className="grid grid-cols-1 gap-4 border-t pt-6 text-sm md:grid-cols-2">
-          <div className="flex items-center space-x-3">
-            <Phone className="h-5 w-5 text-gray-400" />
-            <span>{visita.obra?.cliente.telefono}</span>
+
+        {visita.obra && (
+          <div className="grid grid-cols-1 gap-4 border-t pt-6 text-sm md:grid-cols-2">
+            <div className="flex items-center space-x-3">
+              <Phone className="h-5 w-5 text-gray-400" />
+              <span>{visita.obra.cliente.telefono}</span>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Mail className="h-5 w-5 text-gray-400" />
+              <span>{visita.obra.cliente.mail}</span>
+            </div>
+            <div className="col-span-2 flex items-center space-x-3">
+              <MapPin className="h-5 w-5 text-gray-400" />
+              <span>{visita.direccion_visita || visita.obra.direccion}</span>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Calendar className="h-5 w-5 text-gray-400" />
+              <span>{formatDate(visita.fecha_hora_visita)}</span>
+            </div>
           </div>
-          <div className="flex items-center space-x-3">
-            <Mail className="h-5 w-5 text-gray-400" />
-            <span>{visita.obra?.cliente.mail}</span>
+        )}
+
+        {!visita.obra && visita.direccion_visita && (
+          <div className="border-t pt-6">
+            <div className="flex items-center space-x-3 text-sm">
+              <MapPin className="h-5 w-5 text-gray-400" />
+              <span>{visita.direccion_visita}</span>
+            </div>
+            <div className="mt-2 flex items-center space-x-3 text-sm">
+              <Calendar className="h-5 w-5 text-gray-400" />
+              <span>{formatDate(visita.fecha_hora_visita)}</span>
+            </div>
           </div>
-          <div className="col-span-2 flex items-center space-x-3">
-            <MapPin className="h-5 w-5 text-gray-400" />
-            <span>{visita.obra?.direccion}</span>
+        )}
+
+        {visita.observaciones && (
+          <div>
+            <h4 className="font-semibold text-gray-700">Observaciones</h4>
+            <p className="mt-1 rounded-md border bg-gray-50 p-3 text-gray-600">
+              {visita.observaciones}
+            </p>
           </div>
-          <div className="flex items-center space-x-3">
-            <Calendar className="h-5 w-5 text-gray-400" />
-            <span>{formatDate(visita.fecha_hora_visita)}</span>
+        )}
+
+        {visita.fecha_cancelacion && (
+          <div>
+            <h4 className="font-semibold text-red-600">Fecha de Cancelación</h4>
+            <p className="mt-1 text-sm text-gray-600">
+              {formatDate(visita.fecha_cancelacion)}
+            </p>
           </div>
-        </div>
-        <div>
-          <h4 className="font-semibold text-gray-700">Observaciones</h4>
-          <p className="mt-1 rounded-md border bg-gray-50 p-3 text-gray-600">
-            {visita.observaciones}
-          </p>
-        </div>
+        )}
+
         <div className="flex space-x-4 border-t pt-6">
           <Button className="flex-1 bg-blue-600 text-white hover:bg-blue-700">
             <MapPin className="mr-2 h-4 w-4" /> Cómo llegar
           </Button>
-          {visita.estado === 'PROGRAMADA' && (
+          {canFinalize && (
             <Button
               onClick={onFinalizarVisita}
               className="flex-1 bg-green-600 text-white hover:bg-green-700"

--- a/src/app/dashboard/_components/visitador/VisitadorDashboard.tsx
+++ b/src/app/dashboard/_components/visitador/VisitadorDashboard.tsx
@@ -5,6 +5,7 @@ import type { Visita, EntregaEmpleado } from '@/types'
 import { useGlobalContext } from '@/context/GlobalContext'
 import { useAuth } from '@/context/AuthContext'
 import entregasService from '@/services/entregas.service'
+import visitasService from '@/services/visitas.service'
 import { User as UserIcon, Package } from 'lucide-react'
 
 // Componentes existentes
@@ -17,7 +18,7 @@ import EntregasSidebar from '../planta/EntregasSidebar'
 
 export default function VisitadorDashboard() {
   const { usuario } = useAuth()
-  const { visitas, finalizarVisita } = useGlobalContext()
+  const { finalizarVisita: finalizarVisitaContext } = useGlobalContext()
 
   // Tab activa
   const [activeTab, setActiveTab] = useState<'visitas' | 'entregas'>('visitas')
@@ -26,6 +27,10 @@ export default function VisitadorDashboard() {
   const [selectedVisita, setSelectedVisita] = useState<Visita | null>(null)
   const [showVisitaModal, setShowVisitaModal] = useState(false)
   const [observacionesVisita, setObservacionesVisita] = useState('')
+  const [visitasPendientes, setVisitasPendientes] = useState<Visita[]>([])
+  const [visitasRealizadas, setVisitasRealizadas] = useState<Visita[]>([])
+  const [loadingVisitas, setLoadingVisitas] = useState(true)
+  const [errorVisitas, setErrorVisitas] = useState<string | null>(null)
 
   // Estados para Entregas
   const [selectedEntrega, setSelectedEntrega] =
@@ -38,6 +43,46 @@ export default function VisitadorDashboard() {
   >([])
   const [loadingEntregas, setLoadingEntregas] = useState(true)
   const [errorEntregas, setErrorEntregas] = useState<string | null>(null)
+
+  // Cargar visitas desde la API
+  useEffect(() => {
+    const loadVisitas = async () => {
+      if (!usuario?.cuil) {
+        return
+      }
+      try {
+        setLoadingVisitas(true)
+        setErrorVisitas(null)
+
+        // Cargar visitas programadas y en curso como pendientes
+        const [programadas, enCurso, realizadas] = await Promise.all([
+          visitasService.getVisitasByEmpleadoAndEstado(
+            usuario.cuil,
+            'PROGRAMADA'
+          ),
+          visitasService.getVisitasByEmpleadoAndEstado(
+            usuario.cuil,
+            'EN CURSO'
+          ),
+          visitasService.getVisitasByEmpleadoAndEstado(
+            usuario.cuil,
+            'COMPLETADA'
+          ),
+        ])
+
+        // Combinar programadas y en curso como pendientes
+        setVisitasPendientes([...programadas, ...enCurso])
+        setVisitasRealizadas(realizadas)
+      } catch (err) {
+        console.error('Error al cargar visitas:', err)
+        setErrorVisitas('Error al cargar las visitas')
+      } finally {
+        setLoadingVisitas(false)
+      }
+    }
+
+    loadVisitas()
+  }, [usuario?.cuil])
 
   // Cargar entregas desde la API
   useEffect(() => {
@@ -88,12 +133,90 @@ export default function VisitadorDashboard() {
     setSelectedEntrega(entrega)
   }
 
-  const handleFinalizarVisita = () => {
-    if (selectedVisita) {
-      finalizarVisita(selectedVisita.cod_visita, observacionesVisita)
+  const handleFinalizarVisita = async () => {
+    if (!selectedVisita) return
+
+    try {
+      // Llamar al servicio para finalizar la visita
+      const visitaActualizada = await visitasService.finalizarVisita(
+        selectedVisita.cod_visita,
+        observacionesVisita
+      )
+
+      // Actualizar el estado local
+      setVisitasPendientes((prev) =>
+        prev.filter((v) => v.cod_visita !== selectedVisita.cod_visita)
+      )
+      setVisitasRealizadas((prev) => [visitaActualizada, ...prev])
+
+      // Si existe el contexto global, también actualizarlo
+      if (finalizarVisitaContext) {
+        finalizarVisitaContext(
+          selectedVisita.cod_visita,
+          observacionesVisita
+        )
+      }
+
+      // Actualizar la visita seleccionada
+      setSelectedVisita(visitaActualizada)
+
+      // Cerrar el modal y limpiar observaciones
       setShowVisitaModal(false)
-      setSelectedVisita({ ...selectedVisita, estado: 'COMPLETADA' })
       setObservacionesVisita('')
+    } catch (error) {
+      console.error('Error al finalizar visita:', error)
+      alert('Error al finalizar la visita. Por favor, intenta nuevamente.')
+    }
+  }
+
+  const handleRetryVisitas = () => {
+    // Recargar visitas
+    if (usuario?.cuil) {
+      setLoadingVisitas(true)
+      Promise.all([
+        visitasService.getVisitasByEmpleadoAndEstado(usuario.cuil, 'PROGRAMADA'),
+        visitasService.getVisitasByEmpleadoAndEstado(usuario.cuil, 'EN CURSO'),
+        visitasService.getVisitasByEmpleadoAndEstado(usuario.cuil, 'COMPLETADA'),
+      ])
+        .then(([programadas, enCurso, realizadas]) => {
+          setVisitasPendientes([...programadas, ...enCurso])
+          setVisitasRealizadas(realizadas)
+          setErrorVisitas(null)
+        })
+        .catch((err) => {
+          console.error('Error al recargar visitas:', err)
+          setErrorVisitas('Error al cargar las visitas')
+        })
+        .finally(() => {
+          setLoadingVisitas(false)
+        })
+    }
+  }
+
+  const handleRetryEntregas = () => {
+    // Recargar entregas
+    if (usuario?.cuil) {
+      setLoadingEntregas(true)
+      entregasService
+        .getEntregasByEmpleadoAndEstado(usuario.cuil, 'PENDIENTE')
+        .then((pendientes) => {
+          setEntregasPendientes(pendientes)
+          return entregasService.getEntregasByEmpleadoAndEstado(
+            usuario.cuil,
+            'ENTREGADO'
+          )
+        })
+        .then((entregadas) => {
+          setEntregasRealizadas(entregadas)
+          setErrorEntregas(null)
+        })
+        .catch((err) => {
+          console.error('Error al recargar entregas:', err)
+          setErrorEntregas('Error al cargar las entregas')
+        })
+        .finally(() => {
+          setLoadingEntregas(false)
+        })
     }
   }
 
@@ -104,18 +227,6 @@ export default function VisitadorDashboard() {
       </div>
     )
   }
-
-  // Filtrar visitas asignadas al usuario
-  const visitasAsignadas = visitas.filter((v) =>
-    v.empleados_asignados?.some((emp) => emp.cuil === usuario.cuil)
-  )
-
-  const visitasPendientes = visitasAsignadas.filter(
-    (v) => v.estado === 'PROGRAMADA'
-  )
-  const visitasRealizadas = visitasAsignadas.filter(
-    (v) => v.estado === 'COMPLETADA'
-  )
 
   return (
     <div className="flex h-screen flex-col">
@@ -161,12 +272,30 @@ export default function VisitadorDashboard() {
 
           <div className="space-y-6 p-3">
             {activeTab === 'visitas' ? (
-              <SidebarVisitas
-                visitasPendientes={visitasPendientes}
-                visitasRealizadas={visitasRealizadas}
-                selectedVisita={selectedVisita}
-                onSelectVisita={handleSelectVisita}
-              />
+              loadingVisitas ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-sm text-gray-500">
+                    Cargando visitas...
+                  </div>
+                </div>
+              ) : errorVisitas ? (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+                  <p className="mb-2 text-sm text-red-600">{errorVisitas}</p>
+                  <button
+                    onClick={handleRetryVisitas}
+                    className="text-sm font-medium text-red-700 hover:text-red-800"
+                  >
+                    Reintentar
+                  </button>
+                </div>
+              ) : (
+                <SidebarVisitas
+                  visitasPendientes={visitasPendientes}
+                  visitasRealizadas={visitasRealizadas}
+                  selectedVisita={selectedVisita}
+                  onSelectVisita={handleSelectVisita}
+                />
+              )
             ) : (
               <EntregasSidebar
                 entregasPendientes={entregasPendientes}
@@ -175,7 +304,7 @@ export default function VisitadorDashboard() {
                 onSelectEntrega={handleSelectEntrega}
                 loadingEntregas={loadingEntregas}
                 errorEntregas={errorEntregas}
-                onRetry={() => {}}
+                onRetry={handleRetryEntregas}
               />
             )}
           </div>
@@ -187,7 +316,12 @@ export default function VisitadorDashboard() {
             selectedVisita ? (
               <VisitaDetails
                 visita={selectedVisita}
-                onFinalizarVisita={() => setShowVisitaModal(true)}
+                onFinalizarVisita={() => {
+                  // Solo mostrar modal si la visita está PROGRAMADA o EN CURSO
+                  if (selectedVisita.estado === 'PROGRAMADA' || selectedVisita.estado === 'EN CURSO') {
+                    setShowVisitaModal(true)
+                  }
+                }}
               />
             ) : (
               <div className="flex h-full items-center justify-center text-center">
@@ -196,26 +330,27 @@ export default function VisitadorDashboard() {
                   <p className="mb-4 text-lg text-gray-500">
                     Selecciona una visita para ver los detalles
                   </p>
-                  <div className="flex justify-center gap-4 text-sm">
-                    <div className="text-center">
-                      <div className="font-semibold text-blue-600">
-                        {visitasPendientes.length}
+                  {!loadingVisitas && (
+                    <div className="flex justify-center gap-4 text-sm">
+                      <div className="text-center">
+                        <div className="font-semibold text-blue-600">
+                          {visitasPendientes.length}
+                        </div>
+                        <div className="text-gray-500">Pendientes</div>
                       </div>
-                      <div className="text-gray-500">Pendientes</div>
-                    </div>
-                    <div className="text-center">
-                      <div className="font-semibold text-green-600">
-                        {visitasRealizadas.length}
+                      <div className="text-center">
+                        <div className="font-semibold text-green-600">
+                          {visitasRealizadas.length}
+                        </div>
+                        <div className="text-gray-500">Realizadas</div>
                       </div>
-                      <div className="text-gray-500">Realizadas</div>
                     </div>
-                  </div>
+                  )}
                 </div>
               </div>
             )
           ) : selectedEntrega ? (
             <div className="space-y-4">
-              {/* Usar EntregaDetails existente pero sin el onFinalizarEntrega */}
               <EntregaDetails
                 entrega={selectedEntrega}
                 onFinalizarEntrega={() => {}}
@@ -228,20 +363,22 @@ export default function VisitadorDashboard() {
                 <p className="mb-4 text-lg text-gray-500">
                   Selecciona una entrega para ver los detalles
                 </p>
-                <div className="flex justify-center gap-4 text-sm">
-                  <div className="text-center">
-                    <div className="font-semibold text-blue-600">
-                      {entregasPendientes.length}
+                {!loadingEntregas && (
+                  <div className="flex justify-center gap-4 text-sm">
+                    <div className="text-center">
+                      <div className="font-semibold text-blue-600">
+                        {entregasPendientes.length}
+                      </div>
+                      <div className="text-gray-500">Pendientes</div>
                     </div>
-                    <div className="text-gray-500">Pendientes</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="font-semibold text-green-600">
-                      {entregasRealizadas.length}
+                    <div className="text-center">
+                      <div className="font-semibold text-green-600">
+                        {entregasRealizadas.length}
+                      </div>
+                      <div className="text-gray-500">Entregadas</div>
                     </div>
-                    <div className="text-gray-500">Entregadas</div>
                   </div>
-                </div>
+                )}
               </div>
             </div>
           )}

--- a/src/context/GlobalContext.tsx
+++ b/src/context/GlobalContext.tsx
@@ -8,12 +8,11 @@ import React, {
   useEffect,
 } from 'react'
 import api from '@/services/api/api'
-import { finalizarEntrega } from '@/services/entregas.service'
+import entregasService from '@/services/entregas.service'
+import visitasService from '@/services/visitas.service'
 import {
   mockObras,
   mockClientes,
-  mockEntregas,
-  mockVisitas,
 } from '@/data/mockData'
 import type { Empleado, Obra, Cliente, Entrega, Visita } from '@/types'
 
@@ -23,6 +22,8 @@ interface GlobalContextType {
   clientes: Cliente[]
   entregas: Entrega[]
   visitas: Visita[]
+  loadingVisitas: boolean
+  errorVisitas: string | null
   addEmpleado: (empleado: Omit<Empleado, 'cuil'>) => Promise<void>
   updateEmpleado: (
     cuil: string,
@@ -31,8 +32,9 @@ interface GlobalContextType {
   deleteEmpleado: (cuil: string) => Promise<void>
   currentSection: string
   setCurrentSection: (section: string) => void
-  finalizarEntrega: (id: number, observaciones: string) => void
-  finalizarVisita: (id: number, observaciones: string) => void
+  finalizarEntrega: (id: number, observaciones: string) => Promise<void>
+  finalizarVisita: (id: number, observaciones: string) => Promise<void>
+  reloadVisitas: () => Promise<void>
 }
 
 const GlobalContext = createContext<GlobalContextType | undefined>(undefined)
@@ -42,10 +44,12 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
   const [obras] = useState<Obra[]>(mockObras)
   const [clientes] = useState<Cliente[]>(mockClientes)
   const [currentSection, setCurrentSection] = useState('dashboard')
-  const [entregas] = useState<Entrega[]>(mockEntregas)
-  const [visitas] = useState<Visita[]>(mockVisitas)
+  const [entregas, setEntregas] = useState<Entrega[]>([])
+  const [visitas, setVisitas] = useState<Visita[]>([])
+  const [loadingVisitas, setLoadingVisitas] = useState(true)
+  const [errorVisitas, setErrorVisitas] = useState<string | null>(null)
 
-  // Cargar empleados desde la API al iniciar el contexto
+  // Cargar empleados desde la API
   useEffect(() => {
     const fetchEmpleados = async () => {
       try {
@@ -58,6 +62,29 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
     fetchEmpleados()
   }, [])
 
+  // Cargar visitas desde la API
+  useEffect(() => {
+    loadVisitasData()
+  }, [])
+
+  const loadVisitasData = async () => {
+    try {
+      setLoadingVisitas(true)
+      setErrorVisitas(null)
+      const data = await visitasService.getAllVisitas()
+      setVisitas(data)
+    } catch (error) {
+      console.error('Error al cargar visitas:', error)
+      setErrorVisitas('Error al cargar las visitas')
+    } finally {
+      setLoadingVisitas(false)
+    }
+  }
+
+  const reloadVisitas = async () => {
+    await loadVisitasData()
+  }
+
   const addEmpleado = async (empleadoData: Omit<Empleado, 'cuil'>) => {
     try {
       const { data: nuevoEmpleado } = await api.post<Empleado>(
@@ -67,7 +94,7 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
       setEmpleados((prev) => [...prev, nuevoEmpleado])
     } catch (error) {
       console.error('Error al crear empleado:', error)
-      throw error // Re-lanzamos el error para que el componente lo maneje
+      throw error
     }
   }
 
@@ -99,8 +126,39 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
     }
   }
 
-  const finalizarVisita = (id: number, observaciones: string) => {
-    // Lógica para finalizar visita (posiblemente una llamada a la API en el futuro)
+  const finalizarEntrega = async (id: number, observaciones: string) => {
+    try {
+      // Llamar al servicio de entregas
+      const entregaActualizada = await entregasService.finalizarEntrega(
+        id,
+        observaciones
+      )
+      
+      // Actualizar el estado local si lo estás usando
+      setEntregas((prev) =>
+        prev.map((e) => (e.cod_entrega === id ? entregaActualizada : e))
+      )
+    } catch (error) {
+      console.error('Error al finalizar entrega:', error)
+      throw error
+    }
+  }
+
+  const finalizarVisita = async (id: number, observaciones: string) => {
+    try {
+      const visitaFinalizada = await visitasService.finalizarVisita(
+        id,
+        observaciones
+      )
+      
+      // Actualizar el estado local
+      setVisitas((prev) =>
+        prev.map((v) => (v.cod_visita === id ? visitaFinalizada : v))
+      )
+    } catch (error) {
+      console.error('Error al finalizar visita:', error)
+      throw error
+    }
   }
 
   return (
@@ -111,6 +169,8 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
         clientes,
         entregas,
         visitas,
+        loadingVisitas,
+        errorVisitas,
         addEmpleado,
         updateEmpleado,
         deleteEmpleado,
@@ -118,6 +178,7 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
         setCurrentSection,
         finalizarEntrega,
         finalizarVisita,
+        reloadVisitas,
       }}
     >
       {children}

--- a/src/services/entregas.service.ts
+++ b/src/services/entregas.service.ts
@@ -307,8 +307,34 @@ class EntregasService {
     }
   }
   
-  // ... resto de métodos ...
+  async finalizarEntrega(
+  cod_entrega: number,
+  observaciones?: string
+): Promise<any> {
+  try {
+    const updateData: {
+      estado: 'ENTREGADO'
+      observaciones?: string
+    } = {
+      estado: 'ENTREGADO',
+    }
+
+    if (observaciones) {
+      updateData.observaciones = observaciones
+    }
+
+    const response = await api.put(`
+      ${this.baseURL}/${cod_entrega},
+      updateData`
+    )
+    return response.data
+  } catch (error) {
+    console.error(`Error al finalizar entrega ${cod_entrega}:`, error)
+    throw new Error('No se pudo finalizar la entrega')
+  }
+
+}
 }
 
 const entregasService = new EntregasService()
-export default entregasService
+export default entregasService;

--- a/src/services/visitas.service.ts
+++ b/src/services/visitas.service.ts
@@ -1,0 +1,331 @@
+import api from './api/api'
+import { Visita } from '@/types'
+
+// 1. Definir la estructura que viene del backend
+interface EmpleadoAsignadoVisita {
+  cuil: string
+  cod_visita: number
+  empleado: {
+    cuil: string
+    nombre: string
+    apellido: string
+    rol_actual: string
+    area_trabajo: string
+    contrasenia?: string
+  }
+}
+
+interface BackendVisita {
+  cod_visita: number
+  fecha_hora_visita: string
+  cod_obra?: number
+  cod_postal?: number
+  fecha_cancelacion?: string
+  observaciones?: string
+  motivo_visita: 'MEDICION' | 'RE-MEDICION' | 'REPARACION' | 'ASESORAMIENTO' | 'VISITA INICIAL'
+  estado: 'PROGRAMADA' | 'EN CURSO' | 'CANCELADA' | 'REPROGRAMADA' | 'COMPLETADA'
+  direccion_visita?: string
+  obra?: {
+    cod_obra: number
+    cod_postal: number
+    cuil: string
+    fecha_ini: string
+    estado: 'ACTIVA' | 'EN PRODUCCION' | 'FINALIZADA' | 'ENTREGADA' | 'EN ESPERA DE STOCK'
+    fecha_cancelacion?: string
+    direccion: string
+    nota_fabrica: string
+    cliente: {
+      cuil: string
+      razon_social: string
+      telefono: string
+      mail: string
+    }
+    localidad?: {
+      cod_postal: number
+      nombre_localidad: string
+    }
+  }
+  localidad?: {
+    cod_postal: number
+    nombre_localidad: string
+  }
+  empleado_visita: EmpleadoAsignadoVisita[]
+  uso_vehiculo_visita?: Array<{
+    patente: string
+    fecha_hora_ini_uso: string
+    fecha_hora_fin_est: string
+    fecha_hora_fin_real?: string
+    estado: string
+    vehiculo: {
+      patente: string
+      tipo_vehiculo: string
+      estado: string
+    }
+  }>
+}
+
+// 2. Función para mapear datos del backend al frontend
+const mapToFrontend = (backendVisita: BackendVisita): Visita => {
+  return {
+    cod_visita: backendVisita.cod_visita,
+    fecha_hora_visita: backendVisita.fecha_hora_visita,
+    motivo_visita: backendVisita.motivo_visita as Visita['motivo_visita'],
+    estado: backendVisita.estado as Visita['estado'],
+    observaciones: backendVisita.observaciones,
+    direccion_visita: backendVisita.direccion_visita,
+    fecha_cancelacion: backendVisita.fecha_cancelacion,
+    obra: backendVisita.obra && backendVisita.obra.cliente ? {
+      cod_obra: backendVisita.obra.cod_obra,
+      cod_postal: backendVisita.obra.cod_postal,
+      cuil_cliente: backendVisita.obra.cuil,
+      fecha_ini: backendVisita.obra.fecha_ini,
+      estado: backendVisita.obra.estado,
+      fecha_cancelacion: backendVisita.obra.fecha_cancelacion,
+      direccion: backendVisita.obra.direccion,
+      nota_fabrica: backendVisita.obra.nota_fabrica,
+      cliente: {
+        cuil: backendVisita.obra.cliente.cuil,
+        razon_social: backendVisita.obra.cliente.razon_social,
+        telefono: backendVisita.obra.cliente.telefono,
+        mail: backendVisita.obra.cliente.mail,
+      },
+      localidad: backendVisita.obra.localidad,
+    } : undefined,
+    empleados_asignados: backendVisita.empleado_visita?.map((ev) => ({
+      cuil: ev.empleado?.cuil || ev.cuil,
+      nombre: ev.empleado?.nombre || '',
+      apellido: ev.empleado?.apellido || '',
+      rol_actual: ev.empleado?.rol_actual || '',
+      area_trabajo: ev.empleado?.area_trabajo || '',
+      contrasenia: ev.empleado?.contrasenia,
+    })) || [],
+    vehiculos_usados: backendVisita.uso_vehiculo_visita?.map((uv) => ({
+      patente: uv.patente,
+      cod_visita: backendVisita.cod_visita,
+      fecha_hora_ini_uso: uv.fecha_hora_ini_uso,
+      fecha_hora_fin_est: uv.fecha_hora_fin_est,
+      fecha_hora_fin_real: uv.fecha_hora_fin_real,
+      fecha_hora_ini_est: uv.fecha_hora_fin_est,
+      estado: uv.estado,
+      vehiculo: uv.vehiculo,
+    })),
+  }
+}
+
+class VisitasService {
+  private baseURL = '/visitas'
+
+  /**
+   * Obtener todas las visitas
+   */
+  async getAllVisitas(): Promise<Visita[]> {
+    try {
+      const response = await api.get<BackendVisita[]>(this.baseURL)
+      return response.data.map(mapToFrontend)
+    } catch (error) {
+      console.error('Error al obtener visitas:', error)
+      throw new Error('No se pudieron cargar las visitas')
+    }
+  }
+
+  /**
+   * Obtener una visita por ID
+   */
+  async getVisitaById(cod_visita: number): Promise<Visita> {
+    try {
+      const response = await api.get<BackendVisita>(`${this.baseURL}/${cod_visita}`)
+      return mapToFrontend(response.data)
+    } catch (error) {
+      console.error(`Error al obtener visita ${cod_visita}:`, error)
+      throw new Error('No se pudo cargar la visita')
+    }
+  }
+
+  /**
+   * Crear una nueva visita
+   */
+  async createVisita(data: {
+    fecha_hora_visita: string
+    cod_obra?: number
+    cod_postal?: number
+    motivo_visita: string
+    estado: string
+    observaciones?: string
+    direccion_visita?: string
+  }): Promise<Visita> {
+    try {
+      const response = await api.post<BackendVisita>(this.baseURL, data)
+      return mapToFrontend(response.data)
+    } catch (error) {
+      console.error('Error al crear visita:', error)
+      throw new Error('No se pudo crear la visita')
+    }
+  }
+
+  /**
+   * Actualizar una visita existente
+   */
+  async updateVisita(
+    cod_visita: number,
+    data: {
+      fecha_hora_visita?: string
+      cod_obra?: number
+      cod_postal?: number
+      motivo_visita?: string
+      estado?: string
+      observaciones?: string
+      direccion_visita?: string
+      fecha_cancelacion?: string
+    }
+  ): Promise<Visita> {
+    try {
+      const response = await api.put<BackendVisita>(
+        `${this.baseURL}/${cod_visita}`,
+        data
+      )
+      return mapToFrontend(response.data)
+    } catch (error) {
+      console.error(`Error al actualizar visita ${cod_visita}:`, error)
+      throw new Error('No se pudo actualizar la visita')
+    }
+  }
+
+  /**
+   * Eliminar una visita
+   */
+  async deleteVisita(cod_visita: number): Promise<Visita> {
+    try {
+      const response = await api.delete<BackendVisita>(
+        `${this.baseURL}/${cod_visita}`
+      )
+      return mapToFrontend(response.data)
+    } catch (error) {
+      console.error(`Error al eliminar visita ${cod_visita}:`, error)
+      throw new Error('No se pudo eliminar la visita')
+    }
+  }
+
+  /**
+   * Finalizar una visita (cambiar estado a COMPLETADA)
+   */
+  async finalizarVisita(
+    cod_visita: number,
+    observaciones?: string
+  ): Promise<Visita> {
+    try {
+      const updateData: {
+        estado: string
+        observaciones?: string
+      } = {
+        estado: 'COMPLETADA',
+      }
+
+      if (observaciones) {
+        updateData.observaciones = observaciones
+      }
+
+      const response = await api.put<BackendVisita>(
+        `${this.baseURL}/${cod_visita}`,
+        updateData
+      )
+      return mapToFrontend(response.data)
+    } catch (error) {
+      console.error(`Error al finalizar visita ${cod_visita}:`, error)
+      throw new Error('No se pudo finalizar la visita')
+    }
+  }
+
+  /**
+   * Obtener visitas por empleado y estado
+   */
+  async getVisitasByEmpleadoAndEstado(
+    cuil: string,
+    estado: 'PROGRAMADA' | 'EN CURSO' | 'CANCELADA' | 'REPROGRAMADA' | 'COMPLETADA'
+  ): Promise<Visita[]> {
+    try {
+      // Obtener todas las visitas y filtrar por empleado y estado
+      const allVisitas = await this.getAllVisitas()
+      
+      return allVisitas.filter((visita) => {
+        // Verificar que el empleado esté asignado a la visita
+        const isAssigned = visita.empleados_asignados?.some(
+          (emp) => emp.cuil === cuil
+        )
+        // Verificar que el estado coincida
+        const matchesEstado = visita.estado === estado
+        
+        return isAssigned && matchesEstado
+      })
+    } catch (error) {
+      console.error(
+        `Error al obtener visitas ${estado} para empleado ${cuil}:`,
+        error
+      )
+      throw error
+    }
+  }
+
+  /**
+   * Obtener visitas por empleado
+   */
+  async getVisitasByEmpleado(cuil: string): Promise<Visita[]> {
+    try {
+      const allVisitas = await this.getAllVisitas()
+      
+      return allVisitas.filter((visita) =>
+        visita.empleados_asignados?.some((emp) => emp.cuil === cuil)
+      )
+    } catch (error) {
+      console.error(`Error al obtener visitas del empleado ${cuil}:`, error)
+      throw new Error('No se pudieron cargar las visitas del empleado')
+    }
+  }
+
+  /**
+   * Obtener visitas por obra
+   */
+  async getVisitasByObra(cod_obra: number): Promise<Visita[]> {
+    try {
+      const allVisitas = await this.getAllVisitas()
+      return allVisitas.filter((visita) => visita.obra?.cod_obra === cod_obra)
+    } catch (error) {
+      console.error(`Error al obtener visitas de la obra ${cod_obra}:`, error)
+      throw new Error('No se pudieron cargar las visitas de la obra')
+    }
+  }
+
+  /**
+   * Cancelar una visita
+   */
+  async cancelarVisita(
+    cod_visita: number,
+    observaciones?: string
+  ): Promise<Visita> {
+    try {
+      const updateData: {
+        estado: string
+        fecha_cancelacion: string
+        observaciones?: string
+      } = {
+        estado: 'CANCELADA',
+        fecha_cancelacion: new Date().toISOString(),
+      }
+
+      if (observaciones) {
+        updateData.observaciones = observaciones
+      }
+
+      const response = await api.put<BackendVisita>(
+        `${this.baseURL}/${cod_visita}`,
+        updateData
+      )
+      return mapToFrontend(response.data)
+    } catch (error) {
+      console.error(`Error al cancelar visita ${cod_visita}:`, error)
+      throw new Error('No se pudo cancelar la visita')
+    }
+  }
+}
+
+const visitasService = new VisitasService()
+export default visitasService


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

---

Resumen
Este PR implementa la visualización de visitas y la funcionalidad de finalización de visita, permitiendo que al completarse una visita, su estado se actualice automáticamente a "completada".
Además, se mejoró la estructura general del módulo de visitas para mantener coherencia con las demás entidades del sistema.

---

Cambios Técnicos Implementados
Listado de Visitas:
Creación de endpoint y componente para obtener y mostrar todas las visitas registradas.
Integración con la API para traer datos actualizados.

Finalización de Visita:
Implementación de lógica para actualizar el estado de una visita a COMPLETADA al finalizarla desde el frontend.

Refactor y Estructura:
Ajustes en el servicio de visitas (VisitaService) para soportar las nuevas operaciones.
Validación de estados previos antes de permitir el cambio a completada.
Manejo de errores mejorado y mensajes más claros al usuario.

---

Guía para Pruebas y Revisión
Iniciar el servidor y acceder al panel correspondiente.
Navegar a la sección de “Visitas”.
Verificar que se cargue correctamente el listado de visitas.
Seleccionar una visita en curso y marcarla como finalizada.
Confirmar que su estado cambie automáticamente a “Completada” tanto en frontend como en backend.
Probar casos de error: intentar finalizar una visita ya completada (esperado: mensaje de validación).

---

Screenshots (Opcional)
<!-- Si tus cambios son visuales, añade capturas de pantalla del "antes" y el "después". -->