### PR TITLE
Feat: Implementar notificaciones amigables globales e integrar localización de errores del backend

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -33,7 +33,8 @@ export async function getAccessToken(): Promise<string> {
       body: JSON.stringify({ refreshToken }),
     })
 
-    const data = await response.json()
+    const wrapper = await response.json()
+    const data = wrapper.data || wrapper
     return data.token || data.accessToken
   } catch (error) {
     console.error('[getAccessToken] Token refresh failed:', error)
@@ -73,7 +74,8 @@ export async function loginAction(
       return { error: 'CUIL o contraseña incorrectos' }
     }
 
-    const data = await response.json()
+    const wrapper = await response.json()
+    const data = wrapper.data || wrapper
     const usuario = data.usuario || data.user
     const accessToken = data.accessToken || data.token
     const refreshToken = data.refreshToken

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -27,15 +27,17 @@ export async function getAccessToken(): Promise<string> {
   }
 
   try {
-    const response = await fetchWithErrorHandling(`${API_URL}/auth/refresh`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken }),
-    })
+    const response = await fetchWithErrorHandling<{ token?: string; accessToken?: string }>(
+      `${API_URL}/auth/refresh`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      }
+    )
 
-    const wrapper = await response.json()
-    const data = wrapper.data || wrapper
-    return data.token || data.accessToken
+    const data = await response.json()
+    return data.token || data.accessToken || ''
   } catch (error) {
     console.error('[getAccessToken] Token refresh failed:', error)
     throw new Error('Session expired. Please log in again.')
@@ -58,24 +60,20 @@ export async function loginAction(
   }
 
   try {
-    const response = await fetch(`${API_URL}/auth/login`, {
+    const response = await fetchWithErrorHandling<{
+      usuario?: Empleado
+      user?: Empleado
+      accessToken?: string
+      token?: string
+      refreshToken?: string
+    }>(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ cuil, contrasenia }),
     })
 
-    if (!response.ok) {
-      if (response.status === 429) {
-        return {
-          error:
-            'Se supero el limite de intentos de inicio de sesion. Intente nuevamente mas tarde.',
-        }
-      }
-      return { error: 'CUIL o contraseña incorrectos' }
-    }
+    const data = await response.json()
 
-    const wrapper = await response.json()
-    const data = wrapper.data || wrapper
     const usuario = data.usuario || data.user
     const accessToken = data.accessToken || data.token
     const refreshToken = data.refreshToken
@@ -116,8 +114,9 @@ export async function loginAction(
     const dashboardPath = `/${usuario.rol_actual.toLowerCase()}`
     return { redirectTo: dashboardPath }
   } catch (error) {
-    console.error('[loginAction] Error:', error)
-    return { error: 'Error al iniciar sesión. Intente nuevamente.' }
+    const message = error instanceof Error ? error.message : 'Error al iniciar sesión'
+    console.error('[loginAction] Error:', message)
+    return { error: message }
   }
 }
 

--- a/src/actions/clientes.ts
+++ b/src/actions/clientes.ts
@@ -4,12 +4,8 @@ import { revalidatePath } from 'next/cache'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
 import type { Cliente } from '@/types'
-
-export interface ActionResponse {
-  success: boolean
-  error?: string
-  data?: Cliente
-}
+import type { ActionResponse } from '@/types/actions'
+export type { ActionResponse }
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/clientes') ? API_URL : `${API_URL}/clientes`
@@ -52,7 +48,7 @@ export async function getClientes(filter?: string): Promise<Cliente[]> {
       ? `${BASE_URL}/buscar?q=${encodeURIComponent(filter.trim())}`
       : BASE_URL
 
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Cliente[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -60,7 +56,7 @@ export async function getClientes(filter?: string): Promise<Cliente[]> {
       },
     })
 
-    return (await res.json()) as Cliente[]
+    return await res.json()
   } catch (error) {
     console.error('[getClientes]', error)
     return []
@@ -76,7 +72,7 @@ export async function getCliente(cuil: string): Promise<Cliente | null> {
   if (!cuil) return null
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(
+    const res = await fetchWithErrorHandling<Cliente>(
       `${BASE_URL}/${encodeURIComponent(cuil)}`,
       {
         method: 'GET',
@@ -87,7 +83,7 @@ export async function getCliente(cuil: string): Promise<Cliente | null> {
       }
     )
 
-    return (await res.json()) as Cliente
+    return await res.json()
   } catch (error) {
     console.error('[getCliente]', error)
     return null
@@ -97,16 +93,16 @@ export async function getCliente(cuil: string): Promise<Cliente | null> {
 /**
  * Creates a new Cliente
  * @param {FormData} formData - Cliente data
- * @returns {Promise<ActionResponse>} Operation result
+ * @returns {Promise<ActionResponse<Cliente>>} Operation result
  */
 export async function createCliente(
   formData: FormData
-): Promise<ActionResponse> {
+): Promise<ActionResponse<Cliente>> {
   try {
     const token = await getAccessToken()
     const payload = Object.fromEntries(formData.entries())
 
-    const res = await fetchWithErrorHandling(BASE_URL, {
+    const res = await fetchWithErrorHandling<Cliente>(BASE_URL, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -123,12 +119,9 @@ export async function createCliente(
 
     return { success: true, data }
   } catch (error) {
-    console.error('[createCliente]', error)
-    return {
-      success: false,
-      error:
-        error instanceof Error ? error.message : 'Error al crear el cliente',
-    }
+    const message = error instanceof Error ? error.message : 'Error al crear el cliente'
+    console.error('[createCliente]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -136,18 +129,18 @@ export async function createCliente(
  * Updates an existing Cliente
  * @param {string} cuil - Cliente CUIL identifier
  * @param {FormData} formData - Updated cliente data
- * @returns {Promise<ActionResponse>} Operation result
+ * @returns {Promise<ActionResponse<Cliente>>} Operation result
  */
 export async function updateCliente(
   cuil: string,
   formData: FormData
-): Promise<ActionResponse> {
+): Promise<ActionResponse<Cliente>> {
   if (!cuil) return { success: false, error: 'CUIL inválido' }
   try {
     const token = await getAccessToken()
     const payload = Object.fromEntries(formData.entries())
 
-    const res = await fetchWithErrorHandling(
+    const res = await fetchWithErrorHandling<Cliente>(
       `${BASE_URL}/${encodeURIComponent(cuil)}`,
       {
         method: 'PUT',
@@ -167,25 +160,20 @@ export async function updateCliente(
 
     return { success: true, data }
   } catch (error) {
-    console.error('[updateCliente]', error)
-    return {
-      success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : 'Error al actualizar el cliente',
-    }
+    const message = error instanceof Error ? error.message : 'Error al actualizar el cliente'
+    console.error('[updateCliente]', message)
+    return { success: false, error: message }
   }
 }
 
 /**
  * Deletes a cliente by CUIL
  * @param {string} cuil - Cliente CUIL identifier
- * @returns {Promise<{success: boolean, error?: string}>} Operation result
+ * @returns {Promise<ActionResponse>} Operation result
  */
 export async function deleteCliente(
   cuil: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<ActionResponse> {
   if (!cuil) return { success: false, error: 'CUIL inválido' }
   try {
     const token = await getAccessToken()
@@ -203,10 +191,8 @@ export async function deleteCliente(
 
     return { success: true }
   } catch (error) {
-    console.error('[deleteCliente]', error)
-    return {
-      success: false,
-      error: mapDeleteClienteError(error),
-    }
+    const message = mapDeleteClienteError(error)
+    console.error('[deleteCliente]', message)
+    return { success: false, error: message }
   }
 }

--- a/src/actions/configuraciones.ts
+++ b/src/actions/configuraciones.ts
@@ -4,13 +4,12 @@ import { revalidatePath } from 'next/cache'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
 import type { PerfilFormData } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/empleados/configuraciones')
   ? API_URL
   : `${API_URL}/empleados/configuraciones`
-
-
 
 /**
  * Obtiene la configuración de perfil del usuario
@@ -27,9 +26,7 @@ export async function getPerfilConfig(): Promise<PerfilFormData> {
       },
       next: { revalidate: 30, tags: ['configuraciones-perfil'] },
     })
-    const response = await res.json()
-    // Tu backend devuelve { success: true, data: { nombre, apellido, cuil } }
-    return response
+    return (await res.json()) as PerfilFormData
   } catch (error) {
     console.error('[getPerfilConfig]', error)
     throw error
@@ -39,9 +36,9 @@ export async function getPerfilConfig(): Promise<PerfilFormData> {
 /**
  * Actualiza la configuración de perfil del usuario
  * @param {PerfilFormData} data - Nuevos datos del perfil
- * @returns {Promise<PerfilFormData>}
+ * @returns {Promise<ActionResponse<PerfilFormData>>}
  */
-export async function updatePerfilConfig(data: PerfilFormData): Promise<PerfilFormData> {
+export async function updatePerfilConfig(data: PerfilFormData): Promise<ActionResponse<PerfilFormData>> {
   try {
     const token = await getAccessToken()
     const res = await fetchWithErrorHandling(`${BASE_URL}/perfil`, {
@@ -53,36 +50,28 @@ export async function updatePerfilConfig(data: PerfilFormData): Promise<PerfilFo
       body: JSON.stringify(data),
     })
     
-    // Dependiendo de si tu backend retorna un JSON de respuesta o solo un 200/204
-    let result: Record<string, unknown> = {}
+    let result: PerfilFormData | undefined
     if (res.status !== 204) {
-      try {
-        result = await res.json()
-      } catch {
-        /* ignorar caso donde el cuerpo está vacío y falla el .json() */
-      }
+      result = (await res.json()) as PerfilFormData
     }
     
-    // Revalidad la ruta donde están las configuraciones
     revalidatePath('/configuraciones')
     
-    // Extraer la data del wrapper { success, data } si existe
-    const returnedData = result
-
-    return (Object.keys(returnedData).length > 0 ? returnedData : data) as PerfilFormData
+    return { success: true, data: result || data }
   } catch (error) {
-    console.error('[updatePerfilConfig]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error al actualizar el perfil'
+    console.error('[updatePerfilConfig]', message)
+    return { success: false, error: message }
   }
 }
 
 /**
  * Cambia la contraseña del usuario
  */
-export async function changePasswordConfig(currentPass: string, newPass: string): Promise<Record<string, unknown>> {
+export async function changePasswordConfig(currentPass: string, newPass: string): Promise<ActionResponse> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/password`, {
+    await fetchWithErrorHandling(`${BASE_URL}/password`, {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -91,19 +80,10 @@ export async function changePasswordConfig(currentPass: string, newPass: string)
       body: JSON.stringify({ currentPassword: currentPass, newPassword: newPass }),
     })
     
-    if (res.status === 204) return { success: true }
-    return await res.json()
+    return { success: true }
   } catch (error: unknown) {
-    console.error('[changePasswordConfig]', error)
-    // Extraer el mensaje del error que arroja fetchWithErrorHandling
-    if (error instanceof Error && error.message) {
-      try {
-        const errorData = JSON.parse(error.message)
-        throw new Error(errorData.message || 'Error al cambiar la contraseña')
-      } catch {
-        throw new Error(error.message)
-      }
-    }
-    throw error
+    const message = error instanceof Error ? error.message : 'Error al cambiar la contraseña'
+    console.error('[changePasswordConfig]', message)
+    return { success: false, error: message }
   }
 }

--- a/src/actions/configuraciones.ts
+++ b/src/actions/configuraciones.ts
@@ -29,7 +29,7 @@ export async function getPerfilConfig(): Promise<PerfilFormData> {
     })
     const response = await res.json()
     // Tu backend devuelve { success: true, data: { nombre, apellido, cuil } }
-    return response.data || response
+    return response
   } catch (error) {
     console.error('[getPerfilConfig]', error)
     throw error
@@ -67,7 +67,7 @@ export async function updatePerfilConfig(data: PerfilFormData): Promise<PerfilFo
     revalidatePath('/configuraciones')
     
     // Extraer la data del wrapper { success, data } si existe
-    const returnedData = result.data ? result.data : result
+    const returnedData = result
 
     return (Object.keys(returnedData).length > 0 ? returnedData : data) as PerfilFormData
   } catch (error) {

--- a/src/actions/empleado.ts
+++ b/src/actions/empleado.ts
@@ -4,14 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
 import type { Empleado } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = `${API_URL}/empleados`
-
-interface ApiResponse<T> {
-  success: boolean
-  data: T
-}
 
 interface CreateEmpleadoData {
   cuil: string
@@ -32,12 +28,11 @@ interface UpdateEmpleadoData {
 
 /**
  * Retrieves all Empleados with visitador role
- * @returns {Promise<Empleado[]>} List of visitador Empleados
  */
 export async function getVisitadores(): Promise<Empleado[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/visitadores`, {
+    const res = await fetchWithErrorHandling<Empleado[]>(`${BASE_URL}/visitadores`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -45,8 +40,7 @@ export async function getVisitadores(): Promise<Empleado[]> {
       },
       next: { revalidate: 30, tags: ['empleados', 'visitadores'] },
     })
-    const result = await res.json()
-    return result
+    return await res.json()
   } catch (error) {
     console.error('[getVisitadores]', error)
     return []
@@ -55,12 +49,11 @@ export async function getVisitadores(): Promise<Empleado[]> {
 
 /**
  * Retrieves Empleados available for delivery assignments
- * @returns {Promise<Empleado[]>} List of available Empleados
  */
 export async function getEmpleadosDisponiblesEntrega(): Promise<Empleado[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(
+    const res = await fetchWithErrorHandling<Empleado[]>(
       `${BASE_URL}/disponibles-entrega`,
       {
         method: 'GET',
@@ -71,8 +64,7 @@ export async function getEmpleadosDisponiblesEntrega(): Promise<Empleado[]> {
         next: { revalidate: 30, tags: ['empleados', 'disponibles-entrega'] },
       }
     )
-    const result = await res.json()
-    return result
+    return await res.json()
   } catch (error) {
     console.error('[getEmpleadosDisponiblesEntrega]', error)
     return []
@@ -81,13 +73,11 @@ export async function getEmpleadosDisponiblesEntrega(): Promise<Empleado[]> {
 
 /**
  * Searches Empleados by query parameters
- * @param {string} query - URL query string with filters (e.g., "rol=VISITADOR&area=VENTAS")
- * @returns {Promise<Empleado[]>} Filtered list of Empleados
  */
 export async function searchEmpleados(query: string): Promise<Empleado[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/buscar?${query}`, {
+    const res = await fetchWithErrorHandling<Empleado[]>(`${BASE_URL}/buscar?${query}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -104,18 +94,13 @@ export async function searchEmpleados(query: string): Promise<Empleado[]> {
 
 /**
  * Retrieves a single Empleado by CUIL
- * @param {string} cuil - Empleado's CUIL identifier
- * @returns {Promise<Empleado | null>} Empleado data or null if not found
  */
 export async function getEmpleado(cuil: string): Promise<Empleado | null> {
-  if (!cuil) {
-    console.error('[getEmpleado] Attempted to get Empleado without CUIL')
-    return null
-  }
+  if (!cuil) return null
 
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/${cuil}`, {
+    const res = await fetchWithErrorHandling<Empleado>(`${BASE_URL}/${cuil}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -132,12 +117,11 @@ export async function getEmpleado(cuil: string): Promise<Empleado | null> {
 
 /**
  * Retrieves all Empleados in the system
- * @returns {Promise<Empleado[]>} Complete list of Empleados
  */
 export async function getEmpleados(): Promise<Empleado[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(BASE_URL, {
+    const res = await fetchWithErrorHandling<Empleado[]>(BASE_URL, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -145,8 +129,7 @@ export async function getEmpleados(): Promise<Empleado[]> {
       },
       next: { revalidate: 30, tags: ['empleados'] },
     })
-    const data: Empleado[] = await res.json()
-    return data || []
+    return await res.json()
   } catch (error) {
     console.error('[getEmpleados]', error)
     return []
@@ -155,15 +138,13 @@ export async function getEmpleados(): Promise<Empleado[]> {
 
 /**
  * Creates a new Empleado
- * @param {CreateEmpleadoData} empleadoData - Empleado data
- * @returns {Promise<{success: boolean, data?: Empleado, error?: string}>} Operation result
  */
 export async function createEmpleado(
   empleadoData: CreateEmpleadoData
-): Promise<{ success: boolean; data?: Empleado; error?: string }> {
+): Promise<ActionResponse<Empleado>> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(BASE_URL, {
+    const res = await fetchWithErrorHandling<Empleado>(BASE_URL, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -172,34 +153,29 @@ export async function createEmpleado(
       body: JSON.stringify(empleadoData),
     })
 
-    const empleado: Empleado = await res.json()
+    const data = await res.json()
 
     revalidatePath('/admin/empleados')
     revalidatePath('/coordinacion/empleados')
 
-    return { success: true, data: empleado }
+    return { success: true, data }
   } catch (error) {
-    console.error('[createEmpleado]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Error creating Empleado',
-    }
+    const message = error instanceof Error ? error.message : 'Error creating Empleado'
+    console.error('[createEmpleado]', message)
+    return { success: false, error: message }
   }
 }
 
 /**
  * Updates an existing Empleado
- * @param {string} cuil - Empleado's CUIL identifier
- * @param {UpdateEmpleadoData} empleadoData - Fields to update
- * @returns {Promise<{success: boolean, data?: Empleado, error?: string}>} Operation result
  */
 export async function updateEmpleado(
   cuil: string,
   empleadoData: UpdateEmpleadoData
-): Promise<{ success: boolean; data?: Empleado; error?: string }> {
+): Promise<ActionResponse<Empleado>> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/${cuil}`, {
+    const res = await fetchWithErrorHandling<Empleado>(`${BASE_URL}/${cuil}`, {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -208,30 +184,26 @@ export async function updateEmpleado(
       body: JSON.stringify(empleadoData),
     })
 
-    const empleado: Empleado = await res.json()
+    const data = await res.json()
 
     revalidatePath('/admin/empleados')
     revalidatePath('/coordinacion/empleados')
     revalidatePath(`/admin/empleados/${cuil}`)
 
-    return { success: true, data: empleado }
+    return { success: true, data }
   } catch (error) {
-    console.error('[updateEmpleado]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Error updating Empleado',
-    }
+    const message = error instanceof Error ? error.message : 'Error updating Empleado'
+    console.error('[updateEmpleado]', message)
+    return { success: false, error: message }
   }
 }
 
 /**
  * Deletes an Empleado by CUIL
- * @param {string} cuil - Empleado's CUIL identifier
- * @returns {Promise<{success: boolean, error?: string}>} Operation result
  */
 export async function deleteEmpleado(
   cuil: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<ActionResponse> {
   try {
     const token = await getAccessToken()
     await fetchWithErrorHandling(`${BASE_URL}/${cuil}`, {
@@ -247,10 +219,8 @@ export async function deleteEmpleado(
 
     return { success: true }
   } catch (error) {
-    console.error('[deleteEmpleado]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Error deleting Empleado',
-    }
+    const message = error instanceof Error ? error.message : 'Error deleting Empleado'
+    console.error('[deleteEmpleado]', message)
+    return { success: false, error: message }
   }
 }

--- a/src/actions/empleado.ts
+++ b/src/actions/empleado.ts
@@ -46,7 +46,7 @@ export async function getVisitadores(): Promise<Empleado[]> {
       next: { revalidate: 30, tags: ['empleados', 'visitadores'] },
     })
     const result = await res.json()
-    return Array.isArray(result) ? result : (result.data || [])
+    return result
   } catch (error) {
     console.error('[getVisitadores]', error)
     return []
@@ -72,7 +72,7 @@ export async function getEmpleadosDisponiblesEntrega(): Promise<Empleado[]> {
       }
     )
     const result = await res.json()
-    return Array.isArray(result) ? result : (result.data || [])
+    return result
   } catch (error) {
     console.error('[getEmpleadosDisponiblesEntrega]', error)
     return []
@@ -145,8 +145,8 @@ export async function getEmpleados(): Promise<Empleado[]> {
       },
       next: { revalidate: 30, tags: ['empleados'] },
     })
-    const data: ApiResponse<Empleado[]> = await res.json()
-    return data.data || []
+    const data: Empleado[] = await res.json()
+    return data || []
   } catch (error) {
     console.error('[getEmpleados]', error)
     return []

--- a/src/actions/entregas.ts
+++ b/src/actions/entregas.ts
@@ -14,6 +14,7 @@ import type { Empleado } from '@/types/auth'
 import type { Obra } from '@/types/obra'
 import type { UsoMaquinaria } from '@/types/maquinaria'
 import type { UsoVehiculoEntrega } from '@/types/vehiculo'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = `${API_URL}/entregas`
@@ -86,7 +87,7 @@ export async function getEntregasByEmpleado(
     if (search) url.searchParams.append('search', search)
     if (date) url.searchParams.append('date', date)
 
-    const res = await fetchWithErrorHandling(url.toString(), {
+    const res = await fetchWithErrorHandling<EntregaApiPayload[]>(url.toString(), {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -98,8 +99,8 @@ export async function getEntregasByEmpleado(
         },
       }
     )
-    const entregas: EntregaApiPayload[] = await res.json()
-    return entregas.map((e) => {
+    const entregas = await res.json()
+    return entregas.map((e: EntregaApiPayload) => {
       const ee = (e.entrega_empleado || e.empleados_asignados || []).find(
         (emp: EntregaEmpleadoApi) => emp.cuil === cuilEmpleado
       )
@@ -147,7 +148,7 @@ export async function getEntregas(filter?: string, estado?: string): Promise<Ent
       url = `${BASE_URL}?${params.toString()}`
     }
 
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Entrega[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -156,19 +157,13 @@ export async function getEntregas(filter?: string, estado?: string): Promise<Ent
       next: { revalidate: 30, tags: ['entregas'] },
     })
 
-    const rawEntregas: Record<string, unknown>[] = await res.json()
-    let entregas: Entrega[] = rawEntregas.map((e) => ({
-      ...e,
-      empleados_asignados: e.entrega_empleado || e.empleados_asignados || [],
-      vehiculos: e.uso_vehiculo_entrega || e.vehiculos || [],
-      maquinarias: e.uso_maquinaria || e.maquinarias || [],
-    })) as unknown as Entrega[]
+    let entregas = await res.json()
 
     // Client-side filtering if needed
     if (filter?.trim()) {
       const filterLower = filter.trim().toLowerCase()
 
-      entregas = entregas.filter((entrega) => {
+      entregas = entregas.filter((entrega: Entrega) => {
         const obraDireccion = entrega.obra?.direccion?.toLowerCase() || ''
         const clienteNombre = entrega.obra?.cliente?.nombre?.toLowerCase() || ''
         const clienteApellido =
@@ -181,7 +176,7 @@ export async function getEntregas(filter?: string, estado?: string): Promise<Ent
 
         const empleadosNombres =
           entrega.empleados_asignados
-            ?.map((ea) =>
+            ?.map((ea: { empleado?: { nombre: string; apellido: string } }) =>
               `${ea.empleado?.nombre} ${ea.empleado?.apellido}`.toLowerCase()
             )
             .join(' ') || ''
@@ -214,7 +209,7 @@ export async function getEntregas(filter?: string, estado?: string): Promise<Ent
 export async function getEntrega(id: number): Promise<Entrega | null> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+    const res = await fetchWithErrorHandling<Entrega>(`${BASE_URL}/${id}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -223,36 +218,28 @@ export async function getEntrega(id: number): Promise<Entrega | null> {
       next: { revalidate: 30, tags: [`entrega-${id}`] },
     })
 
-    let data: Record<string, unknown> | null = await res.json()
+    const data = await res.json()
     if (data) {
-      data = {
-        ...data,
-        empleados_asignados:
-          data.entrega_empleado || data.empleados_asignados || [],
+      Object.assign(data, {
+        empleados_asignados: data.entrega_empleado || data.empleados_asignados || [],
         vehiculos: data.uso_vehiculo_entrega || data.vehiculos || [],
         maquinarias: data.uso_maquinaria || data.maquinarias || [],
-      }
+      })
     }
-    return data as unknown as Entrega | null
+    return data
   } catch (error) {
     console.error('[getEntrega]', error)
     return null
   }
 }
 
-/**
- * Finalizes a Entrega
- * @param {number} codEntrega - Entrega ID
- * @param {string} observaciones - Optional final observations
- * @returns {Promise<{success: boolean, data?: unknown, error?: string | null}>} Operation result
- */
 export async function finalizarEntrega(
   codEntrega: number,
   observaciones?: string
-) {
+): Promise<ActionResponse<Entrega>> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(
+    const res = await fetchWithErrorHandling<Entrega>(
       `${BASE_URL}/${codEntrega}/finalizar`,
       {
         method: 'PATCH',
@@ -271,31 +258,24 @@ export async function finalizarEntrega(
     revalidatePath('/planta')
     revalidatePath('/coordinacion/entregas')
 
-    return { success: true, data, error: null }
+    return { success: true, data }
   } catch (error) {
-    console.error('[finalizarEntrega]', error)
+    const message = error instanceof Error ? error.message : 'Error finalizing Entrega'
+    console.error('[finalizarEntrega]', message)
     return {
       success: false,
-      data: null,
-      error:
-        error instanceof Error ? error.message : 'Error finalizing Entrega',
+      error: message,
     }
   }
 }
 
-/**
- * Cancels a Entrega
- * @param {number} codEntrega - Entrega ID
- * @param {string} motivo - Cancellation reason
- * @returns {Promise<{success: boolean, error?: string}>} Operation result
- */
 export async function cancelarEntrega(
   codEntrega: number,
   motivo: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<ActionResponse<Entrega>> {
   try {
     const token = await getAccessToken()
-    await fetchWithErrorHandling(`${BASE_URL}/${codEntrega}/cancelar`, {
+    const res = await fetchWithErrorHandling<Entrega>(`${BASE_URL}/${codEntrega}/cancelar`, {
       method: 'PATCH',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -310,53 +290,57 @@ export async function cancelarEntrega(
     revalidatePath('/coordinacion/entregas')
     return { success: true }
   } catch (error) {
-    console.error('[cancelarEntrega]', error)
+    const message = error instanceof Error ? error.message : 'Error canceling Entrega'
+    console.error('[cancelarEntrega]', message)
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'Error canceling Entrega',
+      error: message,
     }
   }
 }
 
-/**
- * Creates a new Entrega
- * @param {CreateEntregaData} entregaData - Entrega data
- * @returns {Promise<Entrega>} Created Entrega
- */
 export async function createEntrega(
   entregaData: CreateEntregaData
-): Promise<Entrega> {
-  const token = await getAccessToken()
-  const payload = {
-    ...entregaData,
-    empleados: entregaData.empleados_asignados,
-    estado: 'PENDIENTE',
-    maquinarias: entregaData.maquinarias?.map((m) => Number(m)),
-  }
+): Promise<ActionResponse<Entrega>> {
+  try {
+    const token = await getAccessToken()
+    const payload = {
+      ...entregaData,
+      empleados: entregaData.empleados_asignados,
+      estado: 'PENDIENTE',
+      maquinarias: entregaData.maquinarias?.map((m) => Number(m)),
+    }
 
-  const res = await fetchWithErrorHandling(BASE_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  })
+    const res = await fetchWithErrorHandling(BASE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
 
-  let data: Record<string, unknown> | null = await res.json()
-  if (data) {
-    data = {
-      ...data,
-      empleados_asignados:
-        data.entrega_empleado || data.empleados_asignados || [],
-      vehiculos: data.uso_vehiculo_entrega || data.vehiculos || [],
-      maquinarias: data.uso_maquinaria || data.maquinarias || [],
+      const data = await res.json()
+      if (data) {
+        Object.assign(data, {
+          empleados_asignados:
+            data.entrega_empleado || data.empleados_asignados || [],
+          vehiculos: data.uso_vehiculo_entrega || data.vehiculos || [],
+          maquinarias: data.uso_maquinaria || data.maquinarias || [],
+        })
+      }
+      
+      revalidatePath('/coordinacion/entregas')
+      revalidatePath('/planta/entregas')
+      return { success: true, data: data as unknown as Entrega }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error creating Entrega'
+    console.error('[createEntrega]', message)
+    return {
+      success: false,
+      error: message,
     }
   }
-  
-  revalidatePath('/coordinacion/entregas')
-  revalidatePath('/planta/entregas')
-  return data as unknown as Entrega
 }
 
 /**
@@ -368,39 +352,46 @@ export async function createEntrega(
 export async function updateEntrega(
   id: number,
   entregaData: UpdateEntregaData
-): Promise<Entrega> {
-  const token = await getAccessToken()
-  const payload = {
-    ...entregaData,
-    maquinarias: entregaData.maquinarias?.map((m) => Number(m)),
-    cod_ops: entregaData.cod_ops,
-  }
+): Promise<ActionResponse<Entrega>> {
+  try {
+    const token = await getAccessToken()
+    const payload = {
+      ...entregaData,
+      maquinarias: entregaData.maquinarias?.map((m) => Number(m)),
+      cod_ops: entregaData.cod_ops,
+    }
 
-  const res = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  })
+    const res = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
 
-  let data: Record<string, unknown> | null = await res.json()
-  if (data) {
-    data = {
-      ...data,
-      empleados_asignados:
-        data.entrega_empleado || data.empleados_asignados || [],
-      vehiculos: data.uso_vehiculo_entrega || data.vehiculos || [],
-      maquinarias: data.uso_maquinaria || data.maquinarias || [],
+    const data = await res.json()
+    if (data) {
+      Object.assign(data, {
+        empleados_asignados: data.entrega_empleado || data.empleados_asignados || [],
+        vehiculos: data.uso_vehiculo_entrega || data.vehiculos || [],
+        maquinarias: data.uso_maquinaria || data.maquinarias || [],
+      })
+    }
+
+    revalidateTag(`entrega-${id}`)
+    revalidatePath('/coordinacion/entregas')
+    revalidatePath(`/coordinacion/entregas/${id}/editar`)
+
+    return { success: true, data: data as unknown as Entrega }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error updating Entrega'
+    console.error('[updateEntrega]', message)
+    return {
+      success: false,
+      error: message,
     }
   }
-
-  revalidateTag(`entrega-${id}`)
-  revalidatePath('/coordinacion/entregas')
-  revalidatePath(`/coordinacion/entregas/${id}/editar`)
-
-  return data as unknown as Entrega
 }
 
 /**
@@ -408,18 +399,28 @@ export async function updateEntrega(
  * @param {number} id - Entrega ID
  * @returns {Promise<void>}
  */
-export async function deleteEntrega(id: number): Promise<void> {
-  const token = await getAccessToken()
-  await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  })
-  
-  revalidateTag(`entrega-${id}`)
-  revalidatePath('/coordinacion/entregas')
+export async function deleteEntrega(id: number): Promise<ActionResponse> {
+  try {
+    const token = await getAccessToken()
+    await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    revalidateTag(`entrega-${id}`)
+    revalidatePath('/coordinacion/entregas')
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error deleting Entrega'
+    console.error('[deleteEntrega]', message)
+    return {
+      success: false,
+      error: message,
+    }
+  }
 }
 
 /**
@@ -459,7 +460,8 @@ export async function createEntregaFromForm(formData: FormData) {
       maquinarias,
     }
 
-    await createEntrega(entregaData)
+    const res = await createEntrega(entregaData)
+    if (!res.success) throw new Error(res.error)
     revalidatePath('/coordinacion/entregas')
   } catch (error) {
     console.error('[createEntregaFromForm]', error)
@@ -496,7 +498,8 @@ export async function updateEntregaFromForm(formData: FormData) {
       maquinarias,
     }
 
-    await updateEntrega(codEntrega, entregaData)
+    const res = await updateEntrega(codEntrega, entregaData)
+    if (!res.success) throw new Error(res.error)
     revalidatePath('/coordinacion/entregas')
     revalidatePath(`/coordinacion/entregas/${codEntrega}`)
   } catch (error) {

--- a/src/actions/localidad.ts
+++ b/src/actions/localidad.ts
@@ -9,12 +9,11 @@ const BASE_URL = `${API_URL}/provincias`
 
 /**
  * Retrieves all provincias from the system
- * @returns {Promise<Provincia[]>} List of provincias
  */
 export async function getProvincias(): Promise<Provincia[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(BASE_URL, {
+    const res = await fetchWithErrorHandling<Provincia[]>(BASE_URL, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -31,15 +30,13 @@ export async function getProvincias(): Promise<Provincia[]> {
 
 /**
  * Retrieves a single provincia by ID
- * @param {number} cod_provincia - Provincia code/ID
- * @returns {Promise<Provincia | null>} Provincia data or null if not found
  */
 export async function getProvincia(
   cod_provincia: number
 ): Promise<Provincia | null> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/${cod_provincia}`, {
+    const res = await fetchWithErrorHandling<Provincia>(`${BASE_URL}/${cod_provincia}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -56,15 +53,13 @@ export async function getProvincia(
 
 /**
  * Retrieves all localidades belonging to a specific provincia
- * @param {number} cod_provincia - Provincia code/ID
- * @returns {Promise<Localidad[]>} List of localidades in the provincia
  */
 export async function getLocalidadesByProvincia(
   cod_provincia: number
 ): Promise<Localidad[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(
+    const res = await fetchWithErrorHandling<Localidad[]>(
       `${API_URL}/localidades/provincias/${cod_provincia}`,
       {
         method: 'GET',

--- a/src/actions/maquinarias.ts
+++ b/src/actions/maquinarias.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
 import type { Maquinaria, MaquinariaConDisponibilidad } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = `${API_URL}/maquinarias`
@@ -16,7 +17,7 @@ const BASE_URL = `${API_URL}/maquinarias`
 export async function getMaquinarias(search?: string): Promise<Maquinaria[]> {
   const token = await getAccessToken()
   const url = search ? `${BASE_URL}?search=${encodeURIComponent(search)}` : BASE_URL
-  const res = await fetchWithErrorHandling(url, {
+  const res = await fetchWithErrorHandling<Maquinaria[]>(url, {
     headers: { Authorization: `Bearer ${token}` },
     next: { revalidate: 30, tags: ['maquinarias'] },
   })
@@ -29,7 +30,7 @@ export async function getMaquinarias(search?: string): Promise<Maquinaria[]> {
  */
 export async function getMaquinariasDisponibles(): Promise<Maquinaria[]> {
   const token = await getAccessToken()
-  const res = await fetchWithErrorHandling(`${BASE_URL}/disponibles`, {
+  const res = await fetchWithErrorHandling<Maquinaria[]>(`${BASE_URL}/disponibles`, {
     headers: { Authorization: `Bearer ${token}` },
     next: { revalidate: 30, tags: ['maquinarias', 'maquinarias-disponibles'] },
   })
@@ -51,7 +52,7 @@ export async function getDisponibilidadMaquinarias(
     fecha_hora_inicio: fechaInicioISO,
     fecha_hora_fin: fechaFinISO,
   })
-  const res = await fetchWithErrorHandling(
+  const res = await fetchWithErrorHandling<MaquinariaConDisponibilidad[]>(
     `${BASE_URL}/disponibilidad?${params}`,
     {
       headers: { Authorization: `Bearer ${token}` },
@@ -68,7 +69,7 @@ export async function getDisponibilidadMaquinarias(
  */
 export async function getMaquinaria(id: number): Promise<Maquinaria> {
   const token = await getAccessToken()
-  const res = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+  const res = await fetchWithErrorHandling<Maquinaria>(`${BASE_URL}/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
     next: { revalidate: 30, tags: [`maquinaria-${id}`] },
   })
@@ -79,20 +80,28 @@ export async function getMaquinaria(id: number): Promise<Maquinaria> {
  * Creates a new maquinaria and redirects to the list
  * @param {Partial<Maquinaria>} data - Maquinaria data
  */
-export async function createMaquinaria(data: Partial<Maquinaria>) {
-  const token = await getAccessToken()
+export async function createMaquinaria(
+  data: Partial<Maquinaria>
+): Promise<ActionResponse<Maquinaria>> {
+  try {
+    const token = await getAccessToken()
+    const res = await fetchWithErrorHandling(BASE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    })
 
-  await fetchWithErrorHandling(BASE_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
-  })
-
-  revalidatePath('/coordinacion/maquinarias')
-  redirect('/coordinacion/maquinarias')
+    const result = await res.json()
+    revalidatePath('/coordinacion/maquinarias')
+    return { success: true, data: result }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error creating Maquinaria'
+    console.error('[createMaquinaria]', message)
+    return { success: false, error: message }
+  }
 }
 
 /**
@@ -100,20 +109,29 @@ export async function createMaquinaria(data: Partial<Maquinaria>) {
  * @param {number} id - Maquinaria ID
  * @param {Partial<Maquinaria>} data - Fields to update
  */
-export async function updateMaquinaria(id: number, data: Partial<Maquinaria>) {
-  const token = await getAccessToken()
+export async function updateMaquinaria(
+  id: number,
+  data: Partial<Maquinaria>
+): Promise<ActionResponse<Maquinaria>> {
+  try {
+    const token = await getAccessToken()
+    const res = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    })
 
-  await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
-  })
-
-  revalidatePath('/coordinacion/maquinarias')
-  redirect('/coordinacion/maquinarias')
+    const result = await res.json()
+    revalidatePath('/coordinacion/maquinarias')
+    return { success: true, data: result }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error updating Maquinaria'
+    console.error('[updateMaquinaria]', message)
+    return { success: false, error: message }
+  }
 }
 
 /**
@@ -121,14 +139,19 @@ export async function updateMaquinaria(id: number, data: Partial<Maquinaria>) {
  * @param {number} id - Maquinaria ID
  * @returns {Promise<{success: boolean}>} Operation result
  */
-export async function deleteMaquinaria(id: number) {
-  const token = await getAccessToken()
+export async function deleteMaquinaria(id: number): Promise<ActionResponse> {
+  try {
+    const token = await getAccessToken()
+    await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    })
 
-  await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
-  })
-
-  revalidatePath('/coordinacion/maquinarias')
-  return { success: true }
+    revalidatePath('/coordinacion/maquinarias')
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error deleting Maquinaria'
+    console.error('[deleteMaquinaria]', message)
+    return { success: false, error: message }
+  }
 }

--- a/src/actions/obras.ts
+++ b/src/actions/obras.ts
@@ -63,7 +63,7 @@ export async function getObras(filter?: string): Promise<Obra[]> {
       next: { revalidate: 0, tags: ['obras'] },
     })
     const data = await res.json()
-    return Array.isArray(data) ? data : data.data || []
+    return data
   } catch (error) {
     console.error('[getObras]', error)
     return []
@@ -99,7 +99,7 @@ export async function getObrasParaEntrega(
       next: { revalidate: 0, tags: ['obras'] },
     })
     const data = await res.json()
-    return Array.isArray(data) ? data : data.data || []
+    return data
   } catch (error) {
     console.error('[getObrasParaEntrega]', error)
     return []
@@ -124,7 +124,7 @@ export async function getObrasByCliente(cuil: string): Promise<Obra[]> {
       next: { revalidate: 0, tags: [`obras-cliente-${cuil}`] },
     })
     const data = await res.json()
-    return Array.isArray(data) ? data : data.data || []
+    return data
   } catch (error) {
     console.error('[getObrasByCliente]', error)
     return []

--- a/src/actions/obras.ts
+++ b/src/actions/obras.ts
@@ -12,6 +12,7 @@ import type {
   EstadoObra,
   EstadoNotaFabricaProduccion,
 } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/obras') ? API_URL : `${API_URL}/obras`
@@ -24,7 +25,7 @@ const BASE_URL = API_URL.endsWith('/obras') ? API_URL : `${API_URL}/obras`
 export const getObra = cache(async (cod_obra: number): Promise<Obra | null> => {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/${cod_obra}`, {
+    const res = await fetchWithErrorHandling<Obra>(`${BASE_URL}/${cod_obra}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -54,7 +55,7 @@ export async function getObras(filter?: string): Promise<Obra[]> {
     if (filter && filter.trim().length > 0) {
       url = `${BASE_URL}/buscar?q=${encodeURIComponent(filter.trim())}`
     }
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Obra[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -62,8 +63,7 @@ export async function getObras(filter?: string): Promise<Obra[]> {
       },
       next: { revalidate: 0, tags: ['obras'] },
     })
-    const data = await res.json()
-    return data
+    return await res.json()
   } catch (error) {
     console.error('[getObras]', error)
     return []
@@ -90,7 +90,7 @@ export async function getObrasParaEntrega(
 
     const url = `${BASE_URL}/para-entrega?${params.toString()}`
     
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Obra[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -98,8 +98,7 @@ export async function getObrasParaEntrega(
       },
       next: { revalidate: 0, tags: ['obras'] },
     })
-    const data = await res.json()
-    return data
+    return await res.json()
   } catch (error) {
     console.error('[getObrasParaEntrega]', error)
     return []
@@ -115,7 +114,7 @@ export async function getObrasByCliente(cuil: string): Promise<Obra[]> {
   try {
     const token = await getAccessToken()
     const url = `${BASE_URL}/cliente/${encodeURIComponent(cuil)}`
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Obra[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -123,8 +122,7 @@ export async function getObrasByCliente(cuil: string): Promise<Obra[]> {
       },
       next: { revalidate: 0, tags: [`obras-cliente-${cuil}`] },
     })
-    const data = await res.json()
-    return data
+    return await res.json()
   } catch (error) {
     console.error('[getObrasByCliente]', error)
     return []
@@ -151,7 +149,7 @@ export async function filterObras({
     if (estado) params.append('estado', estado)
     if (cod_localidad) params.append('localidad', String(cod_localidad))
     const url = `${BASE_URL}/filtrar?${params.toString()}`
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Obra[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -176,7 +174,7 @@ export async function filterObras({
 export async function uploadNotaFabrica(
   codObra: number,
   file: FormData
-): Promise<Obra> {
+): Promise<ActionResponse<Obra>> {
   try {
     const token = await getAccessToken()
     const res = await fetchWithErrorHandling(
@@ -185,15 +183,16 @@ export async function uploadNotaFabrica(
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: file,
-        timeout: 60000, // 60 segundos para archivos grandes
+        timeout: 60000,
       }
     )
     const data = await res.json()
     revalidatePath('/ventas/obras')
-    return data
+    return { success: true, data }
   } catch (error) {
-    console.error('[uploadNotaFabrica]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error uploading Nota Fabrica'
+    console.error('[uploadNotaFabrica]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -202,7 +201,7 @@ export async function uploadNotaFabrica(
  * @param {number} codObra - Obra code/ID
  * @returns {Promise<Obra>} Updated obra
  */
-export async function deleteNotaFabrica(codObra: number): Promise<Obra> {
+export async function deleteNotaFabrica(codObra: number): Promise<ActionResponse<Obra>> {
   try {
     const token = await getAccessToken()
     const res = await fetchWithErrorHandling(
@@ -217,10 +216,11 @@ export async function deleteNotaFabrica(codObra: number): Promise<Obra> {
     )
     const data = await res.json()
     revalidatePath('/ventas/obras')
-    return data
+    return { success: true, data }
   } catch (error) {
-    console.error('[deleteNotaFabrica]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error deleting Nota Fabrica'
+    console.error('[deleteNotaFabrica]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -247,7 +247,7 @@ export async function getNotasFabricaProduccion({
     const url = `${BASE_URL}/notas-fabrica?${params.toString()}`
 
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Obra[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -279,7 +279,7 @@ export async function getNotasFabricaProduccion({
 export async function createObra(
   obraData: CreateObraInput,
   presupuesto: PresupuestoInput[] | null = null
-): Promise<Obra> {
+): Promise<ActionResponse<Obra>> {
   try {
     const token = await getAccessToken()
     const payload: Record<string, unknown> = { ...obraData }
@@ -300,10 +300,11 @@ export async function createObra(
     })
     const data = await res.json()
     revalidatePath('/ventas/obras')
-    return data
+    return { success: true, data }
   } catch (error: unknown) {
-    console.error('[crearObra]', error)
-    throw error instanceof Error ? error : new Error('Error al crear la obra')
+    const message = error instanceof Error ? error.message : 'Error al crear la obra'
+    console.error('[crearObra]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -316,7 +317,7 @@ export async function createObra(
 export async function updateObra(
   codObra: number,
   obraData: UpdateObraInput
-): Promise<Obra> {
+): Promise<ActionResponse<Obra>> {
   try {
     const token = await getAccessToken()
     const res = await fetchWithErrorHandling(`${BASE_URL}/${codObra}`, {
@@ -330,10 +331,11 @@ export async function updateObra(
     const data = await res.json()
     revalidatePath('/ventas/obras')
     revalidatePath(`/ventas/obras/${codObra}`)
-    return data
+    return { success: true, data }
   } catch (error) {
-    console.error('[actualizarObra]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error updating Obra'
+    console.error('[actualizarObra]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -344,7 +346,7 @@ export async function updateObra(
  */
 export async function deleteObra(
   id: number
-): Promise<{ success: boolean; error?: string }> {
+): Promise<ActionResponse> {
   try {
     const token = await getAccessToken()
     await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
@@ -357,11 +359,9 @@ export async function deleteObra(
     revalidatePath('/ventas/obras')
     return { success: true }
   } catch (error) {
-    console.error('[deleteObra]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    }
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.error('[deleteObra]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -372,7 +372,7 @@ export async function deleteObra(
  */
 export async function cancelObra(
   id: number
-): Promise<{ success: boolean; error?: string }> {
+): Promise<ActionResponse> {
   try {
     const token = await getAccessToken()
     await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
@@ -386,11 +386,9 @@ export async function cancelObra(
     revalidatePath('/ventas/obras')
     return { success: true }
   } catch (error) {
-    console.error('[cancelObra]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    }
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.error('[cancelObra]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -425,21 +423,28 @@ export async function getObrasParaPedidoStock(): Promise<Obra[]> {
  * @param {number} id - Obra ID
  * @returns {Promise<Obra>} Updated obra
  */
-export async function solicitarStockObra(id: number): Promise<Obra> {
-  const token = await getAccessToken()
-  const res = await fetchWithErrorHandling(
-    `${BASE_URL}/${id}/solicitar-stock`,
-    {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    }
-  )
-  revalidatePath('/coordinacion/pedidos')
-  revalidatePath('/ventas/obras')
-  return await res.json()
+export async function solicitarStockObra(id: number): Promise<ActionResponse<Obra>> {
+  try {
+    const token = await getAccessToken()
+    const res = await fetchWithErrorHandling(
+      `${BASE_URL}/${id}/solicitar-stock`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+    const data = await res.json()
+    revalidatePath('/coordinacion/pedidos')
+    revalidatePath('/ventas/obras')
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error al solicitar stock'
+    console.error('[solicitarStockObra]', message)
+    return { success: false, error: message }
+  }
 }
 
 /**
@@ -447,16 +452,23 @@ export async function solicitarStockObra(id: number): Promise<Obra> {
  * @param {number} id - Obra ID
  * @returns {Promise<Obra>} Updated obra
  */
-export async function recibirStockObra(id: number): Promise<Obra> {
-  const token = await getAccessToken()
-  const res = await fetchWithErrorHandling(`${BASE_URL}/${id}/recibir-stock`, {
-    method: 'PATCH',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  })
-  revalidatePath('/coordinacion/pedidos')
-  revalidatePath('/produccion')
-  return await res.json()
+export async function recibirStockObra(id: number): Promise<ActionResponse<Obra>> {
+  try {
+    const token = await getAccessToken()
+    const res = await fetchWithErrorHandling(`${BASE_URL}/${id}/recibir-stock`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    const data = await res.json()
+    revalidatePath('/coordinacion/pedidos')
+    revalidatePath('/produccion')
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error al recibir stock'
+    console.error('[recibirStockObra]', message)
+    return { success: false, error: message }
+  }
 }

--- a/src/actions/ordenes.ts
+++ b/src/actions/ordenes.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
 import type { EstadoOrdenProduccion, OrdenProduccion } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/ordenes-produccion')
@@ -15,10 +16,12 @@ const BASE_URL = API_URL.endsWith('/ordenes-produccion')
  * @param {number} cod_op - Orden de produccion code/ID
  * @returns {Promise<{success: boolean, data?: OrdenProduccion, error?: string}>} Operation result with orden data
  */
-export async function getOrdenProduccion(cod_op: number) {
+export async function getOrdenProduccion(
+  cod_op: number
+): Promise<ActionResponse<OrdenProduccion>> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(`${BASE_URL}/${cod_op}`, {
+    const response = await fetchWithErrorHandling<OrdenProduccion>(`${BASE_URL}/${cod_op}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -27,18 +30,12 @@ export async function getOrdenProduccion(cod_op: number) {
       next: { revalidate: 30, tags: [`orden-${cod_op}`] },
     })
 
-    const orden = await response.json()
-
-    return {
-      success: true,
-      data: orden,
-    }
+    const data = await response.json()
+    return { success: true, data }
   } catch (error) {
-    console.error('[getOrdenProduccion]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Error desconocido',
-    }
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    console.error('[getOrdenProduccion]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -51,7 +48,7 @@ export async function getOrdenesProduccion(
   filtersOrEstado?:
     | EstadoOrdenProduccion
     | OrdenesProduccionBusquedaAvanzadaFilters
-) {
+): Promise<ActionResponse<OrdenProduccion[]>> {
   try {
     const filters =
       typeof filtersOrEstado === 'string' ||
@@ -59,15 +56,14 @@ export async function getOrdenesProduccion(
         ? { estado: filtersOrEstado }
         : filtersOrEstado
 
-    return {
-      success: true,
-      data: await getOrdenesProduccionBusquedaAvanzada(filters),
-    }
+    const data = await getOrdenesProduccionBusquedaAvanzada(filters)
+    return { success: true, data }
   } catch (error) {
-    console.error('[getOrdenesProduccion]', error)
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    console.error('[getOrdenesProduccion]', message)
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'Error desconocido',
+      error: message,
       data: [],
     }
   }
@@ -97,7 +93,7 @@ async function fetchOrdenesConFiltros(
 
   const url = `${BASE_URL}${params.toString() ? `?${params.toString()}` : ''}`
   const token = await getAccessToken()
-  const response = await fetchWithErrorHandling(url, {
+  const response = await fetchWithErrorHandling<OrdenProduccion[]>(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -182,7 +178,7 @@ export async function getOrdenesByObra(
 ): Promise<OrdenProduccion[]> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<OrdenProduccion[]>(
       `${BASE_URL}/obra/${cod_obra}`,
       {
         method: 'GET',
@@ -225,35 +221,28 @@ export async function getOrdenesByObraAndFinalizada(
  * @param {FormData} formData - Form data with cod_obra and PDF file
  * @returns {Promise<{success: boolean, data?: OrdenProduccion, error?: string}>} Operation result
  */
-export async function createOrdenProduccion(formData: FormData) {
+export async function createOrdenProduccion(
+  formData: FormData
+): Promise<ActionResponse<OrdenProduccion>> {
   try {
     const cod_obra = formData.get('cod_obra') as string
     const file = formData.get('file') as File
 
     if (!file || file.size === 0) {
-      return {
-        success: false,
-        error: 'Debe seleccionar un archivo',
-      }
+      return { success: false, error: 'Debe seleccionar un archivo' }
     }
 
     if (file.type !== 'application/pdf') {
-      return {
-        success: false,
-        error: 'Solo se permiten archivos PDF',
-      }
+      return { success: false, error: 'Solo se permiten archivos PDF' }
     }
 
-    // Crear FormData para enviar al backend
     const backendFormData = new FormData()
     backendFormData.append('cod_obra', cod_obra)
     backendFormData.append('file', file)
 
     const token = await getAccessToken()
 
-    // Send directly to backend (has Multer + Cloudinary configured)
-    // DO NOT include Content-Type when sending FormData
-    const response = await fetch(BASE_URL, {
+    const response = await fetchWithErrorHandling(BASE_URL, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -261,26 +250,16 @@ export async function createOrdenProduccion(formData: FormData) {
       body: backendFormData,
     })
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
-      throw new Error(errorData.message || 'Error al crear orden de producción')
-    }
-
     const wrapper = await response.json()
-    const ordenCreada = wrapper.data || wrapper
+    const data = wrapper.data || wrapper
     revalidatePath('/produccion')
     revalidatePath('/obras')
 
-    return {
-      success: true,
-      data: ordenCreada,
-    }
+    return { success: true, data }
   } catch (error) {
-    console.error('[createOrdenProduccion]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Error desconocido',
-    }
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    console.error('[createOrdenProduccion]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -289,7 +268,9 @@ export async function createOrdenProduccion(formData: FormData) {
  * @param {number} cod_op - Orden de produccion code/ID
  * @returns {Promise<{success: boolean, data?: OrdenProduccion, error?: string, message?: string}>} Operation result
  */
-export async function approveOrdenProduccion(cod_op: number) {
+export async function approveOrdenProduccion(
+  cod_op: number
+): Promise<ActionResponse<OrdenProduccion>> {
   try {
     const token = await getAccessToken()
     const response = await fetchWithErrorHandling(`${BASE_URL}/${cod_op}`, {
@@ -304,21 +285,15 @@ export async function approveOrdenProduccion(cod_op: number) {
       }),
     })
 
-    const ordenActualizada = await response.json()
+    const data = await response.json()
     revalidatePath('/dashboard')
     revalidatePath('/coordinacion')
 
-    return {
-      success: true,
-      data: ordenActualizada,
-      message: 'Orden de producción aprobada exitosamente',
-    }
+    return { success: true, data }
   } catch (error) {
-    console.error('[approveOrdenProduccion]', error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Error desconocido',
-    }
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    console.error('[approveOrdenProduccion]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -327,10 +302,12 @@ export async function approveOrdenProduccion(cod_op: number) {
  * @param {number} cod_op - Orden de produccion code/ID
  * @returns {Promise<{success: boolean, message?: string, error?: string}>} Operation result
  */
-export async function startProduccion(cod_op: number) {
+export async function startProduccion(
+  cod_op: number
+): Promise<ActionResponse<OrdenProduccion>> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<OrdenProduccion>(
       `${BASE_URL}/${cod_op}/iniciar`,
       {
         method: 'POST',
@@ -341,21 +318,15 @@ export async function startProduccion(cod_op: number) {
       }
     )
 
-    await response.json()
+    const data = await response.json()
     revalidatePath('/produccion')
     revalidatePath('/coordinacion/ordenes-produccion')
 
-    return {
-      success: true,
-      message: 'Producción iniciada exitosamente',
-    }
+    return { success: true, data }
   } catch (error) {
-    console.error('[startProduccion]', error)
-    return {
-      success: false,
-      error:
-        error instanceof Error ? error.message : 'Error al iniciar producción',
-    }
+    const message = error instanceof Error ? error.message : 'Error al iniciar producción'
+    console.error('[startProduccion]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -364,10 +335,12 @@ export async function startProduccion(cod_op: number) {
  * @param {number} cod_op - Orden de produccion code/ID
  * @returns {Promise<{success: boolean, message?: string, error?: string}>} Operation result
  */
-export async function finishProduccion(cod_op: number) {
+export async function finishProduccion(
+  cod_op: number
+): Promise<ActionResponse<OrdenProduccion>> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<OrdenProduccion>(
       `${BASE_URL}/${cod_op}/finalizar`,
       {
         method: 'POST',
@@ -378,23 +351,15 @@ export async function finishProduccion(cod_op: number) {
       }
     )
 
-    await response.json()
+    const data = await response.json()
     revalidatePath('/produccion')
     revalidatePath('/coordinacion/ordenes-produccion')
 
-    return {
-      success: true,
-      message: 'Producción finalizada exitosamente',
-    }
+    return { success: true, data }
   } catch (error) {
-    console.error('[finishProduccion]', error)
-    return {
-      success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : 'Error al finalizar producción',
-    }
+    const message = error instanceof Error ? error.message : 'Error al finalizar producción'
+    console.error('[finishProduccion]', message)
+    return { success: false, error: message }
   }
 }
 

--- a/src/actions/ordenes.ts
+++ b/src/actions/ordenes.ts
@@ -266,7 +266,8 @@ export async function createOrdenProduccion(formData: FormData) {
       throw new Error(errorData.message || 'Error al crear orden de producción')
     }
 
-    const ordenCreada = await response.json()
+    const wrapper = await response.json()
+    const ordenCreada = wrapper.data || wrapper
     revalidatePath('/produccion')
     revalidatePath('/obras')
 

--- a/src/actions/pagos.ts
+++ b/src/actions/pagos.ts
@@ -8,6 +8,7 @@ import type {
   PagosFilter,
   ObraConPresupuesto,
 } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/pagos') ? API_URL : `${API_URL}/pagos`
@@ -36,7 +37,7 @@ export async function getPagos(filters?: PagosFilter): Promise<Pago[]> {
     const queryString = params.toString()
     const url = `${BASE_URL}${queryString ? `?${queryString}` : ''}`
 
-    const response = await fetchWithErrorHandling(url, {
+    const response = await fetchWithErrorHandling<Pago[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -44,7 +45,6 @@ export async function getPagos(filters?: PagosFilter): Promise<Pago[]> {
       },
       next: { revalidate: 30, tags: ['pagos'] },
     })
-
     return await response.json()
   } catch (error) {
     console.error('[getPagos]', error)
@@ -60,7 +60,7 @@ export async function getPagos(filters?: PagosFilter): Promise<Pago[]> {
 export async function getPagosObra(cod_obra: number): Promise<Pago[]> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<Pago[]>(
       `${BASE_URL}/obra/${cod_obra}`,
       {
         method: 'GET',
@@ -71,7 +71,6 @@ export async function getPagosObra(cod_obra: number): Promise<Pago[]> {
         next: { revalidate: 30, tags: ['pagos', `pagos-obra-${cod_obra}`] },
       }
     )
-
     return await response.json()
   } catch (error) {
     console.error('[getPagosObra]', error)
@@ -96,7 +95,7 @@ export async function getObrasConPresupuestoAceptado(
     const queryString = params.toString()
     const url = `${API_URL}/obras-con-presupuesto${queryString ? `?${queryString}` : ''}`
 
-    const response = await fetchWithErrorHandling(url, {
+    const response = await fetchWithErrorHandling<ObraConPresupuesto[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -109,7 +108,7 @@ export async function getObrasConPresupuestoAceptado(
 
     // Filter only obras with pending balance
     const obrasFiltradas = data.filter((obra: ObraConPresupuesto) => {
-      return obra.saldoPendiente > 0
+      return (obra.saldoPendiente || 0) > 0
     })
 
     return obrasFiltradas
@@ -126,7 +125,7 @@ export async function getObrasConPresupuestoAceptado(
 export async function hayObrasPendientes(): Promise<boolean> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<ObraConPresupuesto[]>(
       `${API_URL}/obras/con-presupuesto-aceptado?search=`,
       {
         method: 'GET',
@@ -138,9 +137,9 @@ export async function hayObrasPendientes(): Promise<boolean> {
       }
     )
 
-    const obras: ObraConPresupuesto[] = await response.json()
+    const obras = await response.json()
     // Return true if there are obras with pending balance > 0
-    return obras.some((obra) => (obra.saldoPendiente || 0) > 0)
+    return obras.some((obra: ObraConPresupuesto) => (obra.saldoPendiente || 0) > 0)
   } catch (error) {
     console.error('[hayObrasPendientes]', error)
     throw error
@@ -156,7 +155,7 @@ export async function hayObrasPendientes(): Promise<boolean> {
 export async function createPagoForObra(
   pagoData: { monto: number },
   cod_obra: number
-): Promise<Pago> {
+): Promise<ActionResponse<Pago>> {
   try {
     const token = await getAccessToken()
     const response = await fetchWithErrorHandling(
@@ -174,10 +173,11 @@ export async function createPagoForObra(
     const data = await response.json()
     revalidatePath('/ventas/pagos')
     revalidatePath('/ventas/obras')
-    return data
+    return { success: true, data }
   } catch (error) {
-    console.error('[createPagoForObra]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error creating Pago'
+    console.error('[createPagoForObra]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -186,7 +186,7 @@ export async function createPagoForObra(
  * @param {number} cod_pago - Pago code/ID
  * @returns {Promise<void>}
  */
-export async function deletePago(cod_pago: number): Promise<void> {
+export async function deletePago(cod_pago: number): Promise<ActionResponse> {
   try {
     const token = await getAccessToken()
     await fetchWithErrorHandling(`${BASE_URL}/${cod_pago}`, {
@@ -199,8 +199,10 @@ export async function deletePago(cod_pago: number): Promise<void> {
 
     revalidatePath('/ventas/pagos')
     revalidatePath('/ventas/obras')
+    return { success: true }
   } catch (error) {
-    console.error('[deletePago]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error deleting Pago'
+    console.error('[deletePago]', message)
+    return { success: false, error: message }
   }
 }

--- a/src/actions/parametros.ts
+++ b/src/actions/parametros.ts
@@ -20,7 +20,7 @@ export async function getActualViatico(): Promise<ParametroViatico> {
       headers: { Authorization: `Bearer ${token}` },
       next: { revalidate: 3600, tags: ['parametros', 'viatico'] }, // 1 hour cache
     })
-    return await res.json()
+    return (await res.json()) as ParametroViatico
   } catch (error: unknown) {
     if (error instanceof Error && error.message !== 'Not found') {
       console.error('[getActualViatico]', error)

--- a/src/actions/vehiculos.ts
+++ b/src/actions/vehiculos.ts
@@ -8,6 +8,7 @@ import type {
   VehiculoFormData,
   VehiculoConDisponibilidad,
 } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/vehiculos')
@@ -22,7 +23,7 @@ export async function getVehiculos(search?: string): Promise<Vehiculo[]> {
   try {
     const token = await getAccessToken()
     const url = search ? `${BASE_URL}?search=${encodeURIComponent(search)}` : BASE_URL
-    const res = await fetchWithErrorHandling(url, {
+    const res = await fetchWithErrorHandling<Vehiculo[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -45,7 +46,7 @@ export async function getVehiculos(search?: string): Promise<Vehiculo[]> {
 export async function getVehiculo(patente: string): Promise<Vehiculo> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/${patente}`, {
+    const res = await fetchWithErrorHandling<Vehiculo>(`${BASE_URL}/${patente}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -69,7 +70,7 @@ export async function getVehiculo(patente: string): Promise<Vehiculo> {
 export async function getVehiculosDisponibles(): Promise<Vehiculo[]> {
   try {
     const token = await getAccessToken()
-    const res = await fetchWithErrorHandling(`${BASE_URL}/disponibles`, {
+    const res = await fetchWithErrorHandling<Vehiculo[]>(`${BASE_URL}/disponibles`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -100,7 +101,7 @@ export async function getDisponibilidadVehiculos(
       fecha_hora_inicio: fechaInicioISO,
       fecha_hora_fin: fechaFinISO,
     })
-    const res = await fetchWithErrorHandling(
+    const res = await fetchWithErrorHandling<VehiculoConDisponibilidad[]>(
       `${BASE_URL}/disponibilidad?${params}`,
       {
         headers: { Authorization: `Bearer ${token}` },
@@ -121,7 +122,7 @@ export async function getDisponibilidadVehiculos(
  */
 export async function createVehiculo(
   data: VehiculoFormData
-): Promise<Vehiculo> {
+): Promise<ActionResponse<Vehiculo>> {
   try {
     const token = await getAccessToken()
     const res = await fetchWithErrorHandling(BASE_URL, {
@@ -132,12 +133,13 @@ export async function createVehiculo(
       },
       body: JSON.stringify(data),
     })
-    const result = await res.json()
+    const data_res = await res.json()
     revalidatePath('/coordinacion/vehiculos')
-    return result
+    return { success: true, data: data_res }
   } catch (error) {
-    console.error('[createVehiculo]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error creating Vehiculo'
+    console.error('[createVehiculo]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -150,7 +152,7 @@ export async function createVehiculo(
 export async function updateVehiculo(
   patente: string,
   data: Partial<VehiculoFormData>
-): Promise<Vehiculo> {
+): Promise<ActionResponse<Vehiculo>> {
   try {
     const token = await getAccessToken()
     const res = await fetchWithErrorHandling(`${BASE_URL}/${patente}`, {
@@ -161,12 +163,13 @@ export async function updateVehiculo(
       },
       body: JSON.stringify(data),
     })
-    const result = await res.json()
+    const data_res = await res.json()
     revalidatePath('/coordinacion/vehiculos')
-    return result
+    return { success: true, data: data_res }
   } catch (error) {
-    console.error('[updateVehiculo]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error updating Vehiculo'
+    console.error('[updateVehiculo]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -175,7 +178,7 @@ export async function updateVehiculo(
  * @param {string} patente - Vehiculo patent/ID
  * @returns {Promise<void>}
  */
-export async function deleteVehiculo(patente: string): Promise<void> {
+export async function deleteVehiculo(patente: string): Promise<ActionResponse> {
   try {
     const token = await getAccessToken()
     await fetchWithErrorHandling(`${BASE_URL}/${patente}`, {
@@ -186,8 +189,10 @@ export async function deleteVehiculo(patente: string): Promise<void> {
       },
     })
     revalidatePath('/coordinacion/vehiculos')
+    return { success: true }
   } catch (error) {
-    console.error('[deleteVehiculo]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error deleting Vehiculo'
+    console.error('[deleteVehiculo]', message)
+    return { success: false, error: message }
   }
 }

--- a/src/actions/visitas.ts
+++ b/src/actions/visitas.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
 import type { Visita, VisitaFormData, MotivoVisita } from '@/types'
+import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
 const BASE_URL = API_URL.endsWith('/visitas') ? API_URL : `${API_URL}/visitas`
@@ -16,7 +17,7 @@ const BASE_URL = API_URL.endsWith('/visitas') ? API_URL : `${API_URL}/visitas`
 export async function getVisita(id: number): Promise<Visita | null> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
+    const response = await fetchWithErrorHandling<Visita>(`${BASE_URL}/${id}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -52,7 +53,7 @@ export async function getVisitas(
         ? `${BASE_URL}/buscar?${queryParams.toString()}`
         : `${BASE_URL}?${queryParams.toString()}`
 
-    const response = await fetchWithErrorHandling(url, {
+    const response = await fetchWithErrorHandling<Visita[]>(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -61,14 +62,14 @@ export async function getVisitas(
       next: { revalidate: 30, tags: ['visitas'] },
     })
 
-    let visitas: Visita[] = await response.json()
+    let visitas = await response.json()
 
     // Client-side filtering as a fallback/refinement if needed,
     // though ideally the backend handles most of it now.
     if (filtro?.trim()) {
       const filtroLower = filtro.trim().toLowerCase()
 
-      visitas = visitas.filter((visita) => {
+      visitas = visitas.filter((visita: Visita) => {
         const nombreCliente = visita.nombre_cliente?.toLowerCase() || ''
         const apellidoCliente = visita.apellido_cliente?.toLowerCase() || ''
         const direccion = visita.direccion_visita?.toLowerCase() || ''
@@ -83,7 +84,7 @@ export async function getVisitas(
 
         const empleadosNombres =
           visita.empleado_visita
-            ?.map((ev) =>
+            ?.map((ev: { empleado?: { nombre: string; apellido: string } }) =>
               `${ev.empleado?.nombre} ${ev.empleado?.apellido}`.toLowerCase()
             )
             .join(' ') || ''
@@ -130,7 +131,7 @@ export async function getVisitasByEmpleado(
     if (search) queryParams.append('search', search)
     if (date) queryParams.append('date', date)
 
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<Visita[]>(
       `${BASE_URL}/empleado/${cuil}?${queryParams.toString()}`,
       {
         method: 'GET',
@@ -152,17 +153,12 @@ export async function getVisitasByEmpleado(
   }
 }
 
-/**
- * Creates a new visita
- * @param {VisitaFormData} visitaData - Visita data
- * @returns {Promise<Visita>} Created visita
- */
 export async function createVisita(
   visitaData: VisitaFormData
-): Promise<Visita> {
+): Promise<ActionResponse<Visita>> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(BASE_URL, {
+    const response = await fetchWithErrorHandling<Visita>(BASE_URL, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -170,26 +166,21 @@ export async function createVisita(
       },
       body: JSON.stringify(visitaData),
     })
-    const result = await response.json()
+    const data = await response.json()
     revalidatePath('/coordinacion/visitas')
     revalidatePath('/visitador')
-    return result
+    return { success: true, data }
   } catch (error) {
-    console.error('[createVisita]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error creating Visita'
+    console.error('[createVisita]', message)
+    return { success: false, error: message }
   }
 }
 
-/**
- * Updates a visita by ID
- * @param {number} id - Visita ID
- * @param {Partial<VisitaFormData>} visitaData - Partial visita data to update
- * @returns {Promise<Visita>} Updated visita
- */
 export async function updateVisita(
   id: number,
   visitaData: Partial<VisitaFormData>
-): Promise<Visita> {
+): Promise<ActionResponse<Visita>> {
   try {
     const token = await getAccessToken()
     const response = await fetchWithErrorHandling(`${BASE_URL}/${id}`, {
@@ -200,30 +191,25 @@ export async function updateVisita(
       },
       body: JSON.stringify(visitaData),
     })
-    const result = await response.json()
+    const data = await response.json()
     revalidatePath('/coordinacion/visitas')
     revalidatePath('/visitador')
     revalidatePath(`/coordinacion/visitas/${id}/editar`)
-    return result
+    return { success: true, data }
   } catch (error) {
-    console.error('[updateVisita]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error updating Visita'
+    console.error('[updateVisita]', message)
+    return { success: false, error: message }
   }
 }
 
-/**
- * Finalizes a visita (changes estado to FINALIZADA)
- * @param {number} codVisita - Visita ID
- * @param {string} observaciones - Optional observations
- * @returns {Promise<{success: boolean, data: unknown, error: string | null}>} Operation result
- */
 export async function finalizarVisita(
   codVisita: number,
   observaciones?: string
-) {
+): Promise<ActionResponse<Visita>> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<Visita>(
       `${BASE_URL}/${codVisita}/finalizar`,
       {
         method: 'PATCH',
@@ -238,23 +224,21 @@ export async function finalizarVisita(
     const data = await response.json()
     revalidatePath('/visitador')
     revalidatePath('/coordinacion/visitas')
-    return { success: true, data, error: null }
+    return { success: true, data }
   } catch (error) {
-    console.error('[finalizarVisita]', error)
-    return { success: false, data: null, error: 'Error al finalizar la visita' }
+    const message = error instanceof Error ? error.message : 'Error al finalizar la visita'
+    console.error('[finalizarVisita]', message)
+    return { success: false, error: message }
   }
 }
 
-/**
- * Cancels a visita (changes estado to CANCELADA)
- * @param {number} codVisita - Visita ID
- * @param {string} motivo - Cancellation reason
- * @returns {Promise<{success: boolean, data: unknown, error: string | null}>} Operation result
- */
-export async function cancelarVisita(codVisita: number, motivo: string) {
+export async function cancelarVisita(
+  codVisita: number,
+  motivo: string
+): Promise<ActionResponse<Visita>> {
   try {
     const token = await getAccessToken()
-    const response = await fetchWithErrorHandling(
+    const response = await fetchWithErrorHandling<Visita>(
       `${BASE_URL}/${codVisita}/cancelar`,
       {
         method: 'PATCH',
@@ -269,10 +253,11 @@ export async function cancelarVisita(codVisita: number, motivo: string) {
     const data = await response.json()
     revalidatePath('/visitador')
     revalidatePath('/coordinacion/visitas')
-    return { success: true, data, error: null }
+    return { success: true, data }
   } catch (error) {
-    console.error('[cancelarVisita]', error)
-    return { success: false, data: null, error: 'Error al cancelar la visita' }
+    const message = error instanceof Error ? error.message : 'Error al cancelar la visita'
+    console.error('[cancelarVisita]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -280,7 +265,7 @@ export async function cancelarVisita(codVisita: number, motivo: string) {
  * Creates a visita from form data and redirects
  * @param {FormData} formData - Form data from client
  */
-export async function createVisitaFromForm(formData: FormData) {
+export async function createVisitaFromForm(formData: FormData): Promise<ActionResponse<Visita>> {
   try {
     const visitaData: VisitaFormData & { fechaSalida?: string; fechaHasta?: string } = {
       fecha_hora_visita: `${formData.get('fecha')}T${formData.get('hora')}:00Z`,
@@ -305,11 +290,11 @@ export async function createVisitaFromForm(formData: FormData) {
       telefono_cliente: (formData.get('clienteTelefono') as string) || null,
     }
 
-    await createVisita(visitaData)
-    revalidatePath('/coordinacion/visitas')
+    return await createVisita(visitaData)
   } catch (error) {
-    console.error('[createVisitaFromForm]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error al procesar el formulario'
+    console.error('[createVisitaFromForm]', message)
+    return { success: false, error: message }
   }
 }
 
@@ -317,7 +302,7 @@ export async function createVisitaFromForm(formData: FormData) {
  * Updates a visita from form data and redirects
  * @param {FormData} formData - Form data from client
  */
-export async function updateVisitaFromForm(formData: FormData) {
+export async function updateVisitaFromForm(formData: FormData): Promise<ActionResponse<Visita>> {
   try {
     const codVisita = Number(formData.get('cod_visita'))
 
@@ -343,10 +328,10 @@ export async function updateVisitaFromForm(formData: FormData) {
       apellido_cliente: (formData.get('apellido') as string) || null,
       telefono_cliente: (formData.get('clienteTelefono') as string) || null,
     }
-    await updateVisita(codVisita, visitaData)
-    revalidatePath('/coordinacion/visitas')
+    return await updateVisita(codVisita, visitaData)
   } catch (error) {
-    console.error('[updateVisitaFromForm]', error)
-    throw error
+    const message = error instanceof Error ? error.message : 'Error al procesar el formulario'
+    console.error('[updateVisitaFromForm]', message)
+    return { success: false, error: message }
   }
 }

--- a/src/app/(dashboard)/coordinacion/vehiculos/[patente]/editar/page.tsx
+++ b/src/app/(dashboard)/coordinacion/vehiculos/[patente]/editar/page.tsx
@@ -44,7 +44,11 @@ export default function EditarVehiculoPage() {
     setError(null)
 
     try {
-      await updateVehiculo(patente, data)
+      const res = await updateVehiculo(patente, data)
+      if (!res.success) {
+        setError(res.error || 'Error al actualizar el vehículo')
+        return
+      }
       router.push('/coordinacion/vehiculos')
       router.refresh()
     } catch (err: unknown) {

--- a/src/app/(dashboard)/coordinacion/vehiculos/crear/page.tsx
+++ b/src/app/(dashboard)/coordinacion/vehiculos/crear/page.tsx
@@ -16,7 +16,11 @@ export default function CrearVehiculoPage() {
     setError(null)
 
     try {
-      await createVehiculo(data)
+      const res = await createVehiculo(data)
+      if (!res.success) {
+        setError(res.error || 'Error al crear el vehículo')
+        return
+      }
       router.push('/coordinacion/vehiculos')
       router.refresh()
     } catch (err: unknown) {

--- a/src/components/coordinacion/CrearEntregaForm.tsx
+++ b/src/components/coordinacion/CrearEntregaForm.tsx
@@ -301,7 +301,6 @@ export default function CrearEntregaForm({
       startTransition(async () => {
         try {
           if (entregaToEdit) {
-            // Filtrar solo los campos permitidos para actualización (UpdateEntregaData)
             const updatePayload = {
               fecha_hora_entrega: entregaData.fecha_hora_entrega,
               detalle: entregaData.detalle,
@@ -313,21 +312,33 @@ export default function CrearEntregaForm({
               maquinarias: entregaData.maquinarias,
               cod_ops: selectedOPs,
             }
-            await updateEntrega(entregaToEdit.cod_entrega, updatePayload)
-            notify.success('Entrega actualizada correctamente.')
+            const res = await updateEntrega(entregaToEdit.cod_entrega, updatePayload)
+            if (res.success) {
+              notify.success('Entrega actualizada correctamente.')
+              router.push('/coordinacion/entregas')
+              router.refresh()
+            } else {
+              setError(res.error || 'Error al actualizar la entrega')
+              notify.error('No se pudo actualizar la entrega. Revise los conflictos.')
+            }
           } else {
-            await createEntrega(entregaData)
-            notify.success('Entrega creada correctamente.')
+            const res = await createEntrega(entregaData)
+            if (res.success) {
+              notify.success('Entrega programada correctamente.')
+              router.push('/coordinacion/entregas')
+              router.refresh()
+            } else {
+              setError(res.error || 'Error al crear la entrega')
+              notify.error('No se pudo crear la entrega. Revise los conflictos.')
+            }
           }
-          router.push('/coordinacion/entregas')
-          router.refresh()
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : 'Error desconocido'
           if (message.includes('NEXT_REDIRECT') || (err as { digest?: string }).digest?.includes('NEXT_REDIRECT')) {
              throw err
           }
           setError(message)
-          notify.error(`Error al procesar la entrega.`)
+          notify.error(`Error de red o del servidor al procesar la entrega.`)
         }
       })
     } catch (err: unknown) {

--- a/src/components/coordinacion/CrearVisita.tsx
+++ b/src/components/coordinacion/CrearVisita.tsx
@@ -224,17 +224,22 @@ export default function CrearVisita({
 
       const action = visitaEditar ? updateVisitaFromForm : createVisitaFromForm
       try {
-        await action(formDataObj)
-        notify.success(visitaEditar ? 'Visita actualizada correctamente.' : 'Visita creada correctamente.')
-        router.push('/coordinacion/visitas')
-        router.refresh()
+        const res = await action(formDataObj)
+        if (res.success) {
+          notify.success(visitaEditar ? 'Visita actualizada correctamente.' : 'Visita programada correctamente.')
+          router.push('/coordinacion/visitas')
+          router.refresh()
+        } else {
+          setError(res.error || 'Error al procesar la visita')
+          notify.error('No se pudo completar la operación. Revise los conflictos de agenda.')
+        }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Error desconocido'
         if (message.includes('NEXT_REDIRECT') || (err as { digest?: string }).digest?.includes('NEXT_REDIRECT')) {
           throw err
         }
         setError(message)
-        notify.error('Error al procesar la visita.')
+        notify.error('Error de red o del servidor al procesar la visita.')
       }
     })
   }

--- a/src/components/coordinacion/PedidosList.tsx
+++ b/src/components/coordinacion/PedidosList.tsx
@@ -51,7 +51,11 @@ export default function PedidosList({ onSchedulePedido }: PedidosListProps) {
   const handleRecibirStock = async (obraId: number) => {
     setUpdatingId(obraId)
     try {
-      await recibirStockObra(obraId)
+      const res = await recibirStockObra(obraId)
+      if (!res.success) {
+        notify.error(res.error || 'Error al confirmar la recepción del stock.')
+        return
+      }
       // Refrescar los datos para que la obra cambie de lista
       await fetchData()
       notify.success('Recepcion de stock confirmada correctamente.')

--- a/src/components/coordinacion/RegistrarPedido.tsx
+++ b/src/components/coordinacion/RegistrarPedido.tsx
@@ -143,11 +143,17 @@ export default function RegistrarPedido({
     setLoading(true)
     setError(null)
     try {
-      const obraActualizada = await solicitarStockObra(preloadedObra.cod_obra)
+      const res = await solicitarStockObra(preloadedObra.cod_obra)
+
+      if (!res.success) {
+        setError(res.error || 'Ocurrió un error al solicitar el stock.')
+        notify.error(res.error || 'Ocurrió un error al solicitar el stock.')
+        return
+      }
 
       setShowModal(false)
       notify.success('Pedido de stock registrado correctamente.')
-      onSubmit(obraActualizada)
+      onSubmit(res.data!)
     } catch (err) {
       const message =
         err instanceof Error

--- a/src/components/coordinacion/maquinaria/MaquinariaForm.tsx
+++ b/src/components/coordinacion/maquinaria/MaquinariaForm.tsx
@@ -37,17 +37,25 @@ export default function MaquinariaForm({
 
     startTransition(async () => {
       try {
+        let res
         if (isEditing) {
-          await updateMaquinaria(maquinariaToEdit.cod_maquina, {
+          res = await updateMaquinaria(maquinariaToEdit.cod_maquina, {
             descripcion: formData.descripcion.trim(),
             estado: formData.estado,
           })
         } else {
-          await createMaquinaria({
+          res = await createMaquinaria({
             descripcion: formData.descripcion.trim(),
             estado: formData.estado,
           })
         }
+
+        if (!res.success) {
+          setError(res.error || 'Error al procesar la maquinaria')
+          notify.error(res.error || 'Error al procesar la maquinaria')
+          return
+        }
+
         notify.success(
           isEditing
             ? 'Maquinaria actualizada correctamente.'

--- a/src/components/coordinacion/orden_produccion/OrdenesProduccionContent.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenesProduccionContent.tsx
@@ -74,7 +74,7 @@ export default function OrdenesProduccionContent({
       const result = await approveOrdenProduccion(ordenToApprove.cod_op)
 
       if (result.success) {
-        notify.success(result.message || 'Orden aprobada exitosamente')
+        notify.success('Orden aprobada exitosamente')
         setIsConfirmModalOpen(false)
         setOrdenToApprove(null)
         router.refresh()

--- a/src/components/pages/MaquinariasPageContent.tsx
+++ b/src/components/pages/MaquinariasPageContent.tsx
@@ -44,7 +44,11 @@ export default function MaquinariasPageContent({
 
     startTransition(async () => {
       try {
-        await deleteMaquinaria(selectedMaquinaria.cod_maquina)
+        const res = await deleteMaquinaria(selectedMaquinaria.cod_maquina)
+        if (!res.success) {
+          notify.error(res.error || 'Error al eliminar la maquinaria')
+          return
+        }
         setShowDeleteModal(false)
         setSelectedMaquinaria(null)
         router.refresh()

--- a/src/components/pages/VehiculosPageContent.tsx
+++ b/src/components/pages/VehiculosPageContent.tsx
@@ -71,7 +71,11 @@ export default function VehiculosPageContent({
       const nuevoEstado =
         estadoActual === 'DISPONIBLE' ? 'FUERA DE SERVICIO' : 'DISPONIBLE'
 
-      await updateVehiculo(patente, { estado: nuevoEstado as VehiculoEstado })
+      const res = await updateVehiculo(patente, { estado: nuevoEstado as VehiculoEstado })
+      if (!res.success) {
+        notify.error(res.error || 'Error al cambiar el estado del vehiculo.')
+        return
+      }
 
       setVehiculos((prev) =>
         prev.map((v) =>
@@ -98,7 +102,11 @@ export default function VehiculosPageContent({
 
   const handleDelete = async (patente: string) => {
     try {
-      await deleteVehiculo(patente)
+      const res = await deleteVehiculo(patente)
+      if (!res.success) {
+        notify.error(res.error || 'No se pudo eliminar el vehiculo.')
+        return
+      }
       setVehiculos((prev) => prev.filter((v) => v.patente !== patente))
       notify.success('Vehiculo eliminado correctamente.')
       router.refresh()

--- a/src/components/shared/ObraCard.tsx
+++ b/src/components/shared/ObraCard.tsx
@@ -58,9 +58,9 @@ export default function ObraCard({
   const handleDelete = () => {
     startTransition(async () => {
       try {
-        const success = await deleteObra(obra.cod_obra)
-        if (!success) {
-          notify.error('No se pudo eliminar la obra. Intente nuevamente.')
+        const res = await deleteObra(obra.cod_obra)
+        if (!res.success) {
+          notify.error(res.error || 'No se pudo eliminar la obra. Intente nuevamente.')
           return
         } else {
           notify.success('Obra eliminada correctamente.')
@@ -77,9 +77,9 @@ export default function ObraCard({
   const handleCancel = () => {
     startTransition(async () => {
       try {
-        const success = await cancelObra(obra.cod_obra)
-        if (!success) {
-          notify.error('No se pudo cancelar la obra. Intente nuevamente.')
+        const res = await cancelObra(obra.cod_obra)
+        if (!res.success) {
+          notify.error(res.error || 'No se pudo cancelar la obra. Intente nuevamente.')
           return
         }
         notify.success('Obra cancelada correctamente.')

--- a/src/components/shared/ObraPagosCard.tsx
+++ b/src/components/shared/ObraPagosCard.tsx
@@ -92,7 +92,7 @@ export default function ObraPagosCard({
           </div>
           <div className="flex items-center gap-4">
             <span className="rounded-full bg-green-200 px-3 py-1 text-xs font-semibold text-green-800 shadow-sm">
-              Total pagado: $ {totalPagado.toLocaleString()}
+              Total pagado: $ {totalPagado.toLocaleString('es-AR')}
             </span>
             {isExpanded ? (
               <ChevronUp className="h-5 w-5 text-gray-500" />
@@ -147,7 +147,7 @@ export default function ObraPagosCard({
                   </div>
                   <div className="flex items-center gap-4">
                     <span className="font-medium text-gray-900">
-                      $ {pago.monto.toLocaleString()}
+                      $ {pago.monto.toLocaleString('es-AR')}
                     </span>
                     {(esVentas || esAdmin) && (
                       <button

--- a/src/components/shared/VisitaDetails.tsx
+++ b/src/components/shared/VisitaDetails.tsx
@@ -55,8 +55,7 @@ export default function VisitaDetail({
         setVisita(data)
       } catch (err: unknown) {
         setError(
-          (err as { message?: string }).message ||
-            'Error al obtener los detalles de la visita.'
+          err instanceof Error ? err.message : 'Error al obtener los detalles de la visita.'
         )
       } finally {
         setLoading(false)

--- a/src/components/shared/configuraciones/ChangePasswordModal.tsx
+++ b/src/components/shared/configuraciones/ChangePasswordModal.tsx
@@ -68,8 +68,7 @@ export function ChangePasswordModal({
       handleClose()
     } catch (err: unknown) {
       setError(
-        (err as { message?: string }).message ||
-          'Error al actualizar la contraseña.'
+        err instanceof Error ? err.message : 'Error al actualizar la contraseña.'
       )
       setLoading(false)
     }

--- a/src/components/shared/configuraciones/SeguridadSection.tsx
+++ b/src/components/shared/configuraciones/SeguridadSection.tsx
@@ -10,7 +10,7 @@ export function SeguridadSection() {
     // Aquí invocamos al server action
     const res = await changePasswordConfig(current, newPass)
     if (res && res.success === false) {
-      throw new Error((res.message as string) || 'Error al cambiar la contraseña')
+      throw new Error(res.error || 'Error al cambiar la contraseña')
     }
   }
 

--- a/src/components/ventas/CrearObra.tsx
+++ b/src/components/ventas/CrearObra.tsx
@@ -335,10 +335,16 @@ export default function CrearObra({
       const dataToSend = { ...formData }
       delete dataToSend.fecha_cancelacion
 
+      let res
       if (esModoEdicion && obraExistente) {
-        await updateObra(obraExistente.cod_obra, dataToSend)
+        res = await updateObra(obraExistente.cod_obra, dataToSend)
       } else {
-        await createObra(dataToSend, presupuestos)
+        res = await createObra(dataToSend, presupuestos)
+      }
+
+      if (!res.success) {
+        notify.error(res.error || 'Error al guardar la obra.')
+        return
       }
 
       notify.success(

--- a/src/components/ventas/NotaFabricaModal.tsx
+++ b/src/components/ventas/NotaFabricaModal.tsx
@@ -69,12 +69,18 @@ export default function NotaFabricaModal({
       const formData = new FormData()
       formData.append('file', selectedFile)
 
-      const obraActualizada = await uploadNotaFabrica(codObra, formData)
+      const res = await uploadNotaFabrica(codObra, formData)
+
+      if (!res.success) {
+        setError(res.error || 'Error al subir la nota de fábrica.')
+        notify.error(res.error || 'Error al subir la nota de fábrica.')
+        return
+      }
 
       setSelectedFile(null)
       setModoCambio(false)
       // Devolver el public_id, no la URL
-      onUploadSuccess?.(obraActualizada.nota_fabrica_pid || '')
+      onUploadSuccess?.(res.data!.nota_fabrica_pid || '')
       notify.success('Nota de fabrica actualizada correctamente.')
       router.refresh() // Recargar la página para actualizar el botón
       onClose()
@@ -95,8 +101,13 @@ export default function NotaFabricaModal({
       setIsDeleting(true)
       setLoading(true)
       setError(null)
-      const obraActualizada = await deleteNotaFabrica(codObra)
-      onUploadSuccess?.(obraActualizada.nota_fabrica_pid || '')
+      const res = await deleteNotaFabrica(codObra)
+      if (!res.success) {
+        setError(res.error || 'Error al eliminar la nota de fábrica.')
+        notify.error(res.error || 'Error al eliminar la nota de fábrica.')
+        return
+      }
+      onUploadSuccess?.(res.data!.nota_fabrica_pid || '')
       setModoCambio(false)
       notify.success('Nota de fabrica eliminada correctamente.')
       router.refresh() // Recargar la página
@@ -118,8 +129,13 @@ export default function NotaFabricaModal({
     try {
       setLoading(true)
       setError(null)
-      const obraActualizada = await deleteNotaFabrica(codObra)
-      onUploadSuccess?.(obraActualizada.nota_fabrica_pid || '')
+      const res = await deleteNotaFabrica(codObra)
+      if (!res.success) {
+        setError(res.error || 'Error al eliminar la nota de fábrica.')
+        notify.error(res.error || 'Error al eliminar la nota de fábrica.')
+        return
+      }
+      onUploadSuccess?.(res.data!.nota_fabrica_pid || '')
       setModoCambio(true)
       setSelectedFile(null)
       notify.info('Nota eliminada. Ya puedes subir una nueva.')

--- a/src/components/ventas/PagoCard.tsx
+++ b/src/components/ventas/PagoCard.tsx
@@ -26,7 +26,11 @@ export default function PagoCard({
   const handleDelete = async () => {
     setLoading(true)
     try {
-      await deletePago(pago.cod_pago)
+      const res = await deletePago(pago.cod_pago)
+      if (!res.success) {
+        notify.error(res.error || 'Error al eliminar el pago')
+        return
+      }
       setShowConfirm(false)
       onRefresh?.()
     } catch {

--- a/src/components/ventas/pagos/PagoModal.tsx
+++ b/src/components/ventas/pagos/PagoModal.tsx
@@ -179,21 +179,23 @@ export default function PagoModal({
       setLoading(true)
       setError(null)
 
-      const nuevoPago = await createPagoForObra(
+      const res = await createPagoForObra(
         { monto: montoNumerico },
         selectedObra.cod_obra
       )
 
+      if (!res.success) {
+        setError(res.error || 'Error al crear el pago')
+        notify.error(res.error || 'Error al crear el pago')
+        return
+      }
+
       notify.success('Pago registrado correctamente.')
-      onPagoCreado(nuevoPago)
+      onPagoCreado(res.data!)
       handleClose()
     } catch (err: unknown) {
-      const errorMessage =
+      const message =
         err instanceof Error ? err.message : 'Error al crear el pago'
-      const backendError = (
-        err as unknown as { response?: { data?: { message?: string } } }
-      )?.response?.data?.message
-      const message = backendError || errorMessage
       setError(message)
       notify.error(message)
     } finally {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -36,7 +36,8 @@ export const getProvincias = cache(async (): Promise<Provincia[]> => {
     })
 
     if (!res.ok) return []
-    return res.json()
+    const wrapper = await res.json()
+    return wrapper.data || wrapper
   } catch (error) {
     console.error('Error obteniendo provincias:', error)
     return []

--- a/src/lib/fetchWithErrorHandling.ts
+++ b/src/lib/fetchWithErrorHandling.ts
@@ -25,6 +25,17 @@ export async function fetchWithErrorHandling(
       }
       throw new Error(errorMsg)
     }
+
+    // Intercept .json() to support standardized backend responses { status: 'success', data: ... }
+    const originalJson = res.json.bind(res)
+    res.json = async () => {
+      const json = await originalJson()
+      if (json && json.status === 'success' && json.data !== undefined) {
+        return json.data
+      }
+      return json
+    }
+
     return res
   } catch (err: unknown) {
     if (err instanceof Error) {

--- a/src/lib/fetchWithErrorHandling.ts
+++ b/src/lib/fetchWithErrorHandling.ts
@@ -1,7 +1,7 @@
-export async function fetchWithErrorHandling(
+export async function fetchWithErrorHandling<T = unknown>(
   url: string,
   options: RequestInit & { timeout?: number } = {}
-) {
+): Promise<Response & { json(): Promise<T> }> {
   const { timeout = 10000, ...fetchOptions } = options
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeout)
@@ -14,42 +14,73 @@ export async function fetchWithErrorHandling(
     clearTimeout(timeoutId)
 
     if (!res.ok) {
-      if (res.status === 401) throw new Error('Unauthorized')
-      if (res.status === 404) throw new Error('Not found')
-      let errorMsg = `HTTP ${res.status}`
+      let errorMsg = `Error HTTP ${res.status}`
       try {
-        const errorData = await res.json()
-        errorMsg = errorData.message || errorData.error || errorMsg
+        const errorData = (await res.json()) as { 
+          message?: string; 
+          error?: string; 
+          errorCode?: string; 
+          status?: string;
+          details?: string;
+        }
+        
+        // El backend ahora centraliza las traducciones al español mediante ERROR_MAP.
+        // Priorizamos el 'message' que ya viene localizado.
+        if (errorData.message) {
+          errorMsg = errorData.message
+        } else if (errorData.error) {
+          errorMsg = errorData.error
+        }
+        
+        // Si hay una lista de detalles (como conflictos de agenda), los agregamos.
+        if (Array.isArray(errorData.details)) {
+          // Si los detalles son un array de strings o objetos con mensaje, los unimos.
+          const detailsStr = errorData.details
+            .map((d: unknown) => {
+              if (typeof d === 'string') return d
+              if (d && typeof d === 'object' && 'message' in d) return String(d.message)
+              return JSON.stringify(d)
+            })
+            .join('\n')
+          if (detailsStr) {
+            errorMsg += `:\n${detailsStr}`
+          }
+        }
       } catch {
-        // Ignore parsing errors for non-JSON responses
+        if (res.status === 401) errorMsg = 'Sesión expirada o no autorizada'
+        if (res.status === 404) errorMsg = 'Recurso no encontrado'
       }
       throw new Error(errorMsg)
     }
 
     // Intercept .json() to support standardized backend responses { status: 'success', data: ... }
     const originalJson = res.json.bind(res)
-    res.json = async () => {
-      const json = await originalJson()
+    res.json = async <R = unknown>() => {
+      const json = (await originalJson()) as { 
+        status: string; 
+        data: R; 
+        message?: string 
+      }
       if (json && json.status === 'success' && json.data !== undefined) {
         return json.data
       }
-      return json
+      return json as unknown as R
     }
 
     return res
   } catch (err: unknown) {
     if (err instanceof Error) {
-      if (err.name === 'AbortError') throw new Error('Request timeout')
-      // Check for ECONNREFUSED, assuming err.cause might be an object with a code property
-      if (typeof err.cause === 'object' && err.cause !== null && 'code' in err.cause && err.cause.code === 'ECONNREFUSED') {
+      if (err.name === 'AbortError') throw new Error('Tiempo de espera agotado')
+      
+      // Handle network errors (ECONNREFUSED)
+      const cause = err.cause as { code?: string } | undefined
+      if (cause?.code === 'ECONNREFUSED') {
         throw new Error(
-          'No se puede conectar al servidor backend. Verifica que esté corriendo en ' +
-            (url.startsWith('http') ? new URL(url).origin : 'la URL configurada')
+          'No se puede conectar al servidor backend. Verifica que esté corriendo.'
         )
       }
-      throw err // Re-throw the error if it's an Error instance but not specifically handled
+      throw err
     }
-    // If err is not an instance of Error, throw a generic error
-    throw new Error('Ha ocurrido un error inesperado al realizar la petición')
+    throw new Error('Ha ocurrido un error inesperado')
   }
 }

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,0 +1,10 @@
+/**
+ * Generic response for Server Actions.
+ * T represents the data type returned on success.
+ */
+export interface ActionResponse<T = unknown> {
+  success: boolean
+  error?: string
+  errorCode?: string // Optional field for specific error code handling if needed
+  data?: T
+}


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
Este PR simplifica la capa de conexiones del cliente y estandariza los mensajes mostrados en la interfaz, aprovechando la localización nativa en español proveída ahora por el Backend y mejorando la seguridad de tipos.

### Cambios Técnicos Implementados
- **Refactorización del Cliente HTTP:** Se reescribió la lógica en `fetchWithErrorHandling.ts` para evitar mapas de errores locales duplicados. Ahora, la UI confía plenamente en el campo `message` de la API de backend.
- **Manejo Dinámico de Conflictos:** Se implementó una lógica recursiva en los componentes que interceptan la respuesta (por ejemplo: conflictos de agenda) para iterar detalles proporcionados por la API y formatearlos con saltos de línea legibles (`\n`).
- **Correcciones UI/UX (Notificaciones Toast):** Los errores de validación arrojados por Zod o por inicio de sesión (credenciales fallidas) se pasaron a manejar mediante alertas tipo "Toast" para no romper el layout y dar un aspecto visual más premium.
- **Limpieza de Tipos:** Se implementó `unknown` en las capturas de error globales en sustitución a los primitivos `any` desaconsejados, validando correctamente `obj instanceof Error`.

---

### Guía para Pruebas y Revisión
1. Iniciar la aplicación y levantar el entorno local usando `pnpm run dev`.
2. Probar forzar un error, como ingresar un CUIL que no exista o una contraseña incorrecta en la terminal de autenticación.
3. Comprobar visualmente que en la esquina aparece correctamente un Toast color rojo, naturalizado, dictando "CUIL o contraseña incorrectos" usando la fuente del layout principal (Inter/Roboto), sin mostrar errores de red rudos ni en inglés.
4. **Verificar Fallos Cruzados:** Agendar una Entrega desde un vehículo o empleado previamente reservado en la misma fecha y comprobar en pantalla un formato legible de las coincidencias superpuestas enviadas por las integraciones del backend.