### PR TITLE
fix: display client name and surname as fallback for individual clients

### DIFF
--- a/src/components/planta/EntregaDetails.tsx
+++ b/src/components/planta/EntregaDetails.tsx
@@ -77,6 +77,7 @@ export default function EntregaDetails({
               </h2>
               <p className="mb-3 text-lg text-gray-600 lg:text-xl">
                 {entrega.obra.cliente?.razon_social ||
+                  [entrega.obra.cliente?.nombre, entrega.obra.cliente?.apellido].filter(Boolean).join(' ') ||
                   'Cliente no especificado'}
               </p>
               <div className="mt-3 flex flex-wrap items-center gap-3">

--- a/src/components/visitador/VisitaDetailsVisitador.tsx
+++ b/src/components/visitador/VisitaDetailsVisitador.tsx
@@ -119,7 +119,10 @@ export default function VisitaDetails({
               Visita #{visita.cod_visita}
             </h2>
             <p className="mb-3 text-lg text-gray-600 lg:text-xl">
-              {visita.obra?.cliente.razon_social || 'Visita sin obra asignada'}
+              {visita.obra?.cliente.razon_social ||
+                [visita.obra?.cliente.nombre, visita.obra?.cliente.apellido].filter(Boolean).join(' ') ||
+                [visita.nombre_cliente, visita.apellido_cliente].filter(Boolean).join(' ') ||
+                'Visita sin obra asignada'}
             </p>
             <div className="mt-3 flex flex-wrap items-center gap-3">
               <span


### PR DESCRIPTION
Se corrigió el nombre del cliente en las vistas de visitas y entregas para mostrar nombre y apellido cuando el cliente es persona física y no tiene razon_social.