### PR TITLE
Feature/op visita linking

### DIFF
--- a/src/actions/ordenes.ts
+++ b/src/actions/ordenes.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, revalidateTag } from 'next/cache'
 import { fetchWithErrorHandling } from '@/lib/fetchWithErrorHandling'
 import { getAccessToken } from './auth'
-import type { EstadoOrdenProduccion, OrdenProduccion } from '@/types'
+import type { EstadoOrdenProduccion, OrdenProduccion, PaginatedResponse } from '@/types'
 import type { ActionResponse } from '@/types/actions'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
@@ -45,21 +45,23 @@ export async function getOrdenProduccion(
 /**
  * Retrieves ordenes de produccion with optional estado/date filters.
  * Accepts either a plain estado string or a filters object.
- * @returns {Promise<{success: boolean, data: OrdenProduccion[], error?: string}>} Operation result with ordenes list
+ * @returns {Promise<ActionResponse<PaginatedResponse<OrdenProduccion>>>} Operation result with paginated ordenes list
  */
 export async function getOrdenesProduccion(
   filtersOrEstado?:
     | EstadoOrdenProduccion
-    | OrdenesProduccionBusquedaAvanzadaFilters
-): Promise<ActionResponse<OrdenProduccion[]>> {
+    | OrdenesProduccionBusquedaAvanzadaFilters,
+  page: number = 1,
+  pageSize: number = 25
+): Promise<ActionResponse<PaginatedResponse<OrdenProduccion>>> {
   try {
     const filters =
       typeof filtersOrEstado === 'string' ||
-      typeof filtersOrEstado === 'undefined'
+        typeof filtersOrEstado === 'undefined'
         ? { estado: filtersOrEstado }
         : filtersOrEstado
 
-    const data = await getOrdenesProduccionBusquedaAvanzada(filters)
+    const data = await getOrdenesProduccionBusquedaAvanzada(filters, page, pageSize)
     return { success: true, data }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Error desconocido'
@@ -67,7 +69,7 @@ export async function getOrdenesProduccion(
     return {
       success: false,
       error: message,
-      data: [],
+      data: { data: [], total: 0, totalPages: 0, page, pageSize },
     }
   }
 }
@@ -88,17 +90,21 @@ export type OrdenesProduccionBusquedaAvanzadaFilters =
 async function fetchOrdenesConFiltros(
   filters: OrdenesProduccionBusquedaAvanzadaFilters,
   revalidate: number,
-  tags: string[]
-): Promise<OrdenProduccion[]> {
+  tags: string[],
+  page: number = 1,
+  pageSize: number = 25
+): Promise<PaginatedResponse<OrdenProduccion>> {
   const params = new URLSearchParams()
   if (filters.estado) params.set('estado', filters.estado)
   if (filters.fechaDesde) params.set('fechaDesde', filters.fechaDesde)
   if (filters.fechaHasta) params.set('fechaHasta', filters.fechaHasta)
   if (filters.cod_obra) params.set('cod_obra', String(filters.cod_obra))
+  params.set('page', String(page))
+  params.set('pageSize', String(pageSize))
 
-  const url = `${BASE_URL}${params.toString() ? `?${params.toString()}` : ''}`
+  const url = `${BASE_URL}?${params.toString()}`
   const token = await getAccessToken()
-  const response = await fetchWithErrorHandling<OrdenProduccion[]>(url, {
+  const response = await fetchWithErrorHandling<PaginatedResponse<OrdenProduccion>>(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -108,7 +114,11 @@ async function fetchOrdenesConFiltros(
   })
 
   const data = await response.json()
-  return Array.isArray(data) ? data : []
+  if (data && typeof data === 'object' && 'data' in data && Array.isArray(data.data)) {
+    return data as PaginatedResponse<OrdenProduccion>
+  }
+
+  return { data: [], total: 0, totalPages: 0, page, pageSize }
 }
 
 /**
@@ -118,20 +128,19 @@ export async function getOrdenesProduccionPorEstadoYFechas({
   estado,
   fechaDesde,
   fechaHasta,
-}: OrdenesProduccionEstadoFechasFilters): Promise<OrdenProduccion[]> {
+  page = 1,
+  pageSize = 25,
+}: OrdenesProduccionEstadoFechasFilters & { page?: number, pageSize?: number }): Promise<PaginatedResponse<OrdenProduccion>> {
   try {
     const estadoTag = estado ? estado.replace(/\s+/g, '-').toLowerCase() : 'all'
 
     return await fetchOrdenesConFiltros({ estado, fechaDesde, fechaHasta }, 0, [
       'ordenes-produccion',
       `ordenes-produccion-${estadoTag}`,
-    ])
+    ], page, pageSize)
   } catch (error) {
-    if (error instanceof Error && error.message === 'Not found') {
-      return []
-    }
     console.error('[getOrdenesProduccionPorEstadoYFechas]', error)
-    return []
+    return { data: [], total: 0, totalPages: 0, page, pageSize }
   }
 }
 
@@ -140,19 +149,18 @@ export async function getOrdenesProduccionBusquedaAvanzada({
   fechaDesde,
   fechaHasta,
   cod_obra,
-}: OrdenesProduccionBusquedaAvanzadaFilters): Promise<OrdenProduccion[]> {
+}: OrdenesProduccionBusquedaAvanzadaFilters, page: number = 1, pageSize: number = 25): Promise<PaginatedResponse<OrdenProduccion>> {
   try {
     return await fetchOrdenesConFiltros(
       { estado, fechaDesde, fechaHasta, cod_obra },
       30,
-      ['ordenes-produccion']
+      ['ordenes-produccion'],
+      page,
+      pageSize
     )
   } catch (error) {
-    if (error instanceof Error && error.message === 'Not found') {
-      return []
-    }
     console.error('[getOrdenesProduccionBusquedaAvanzada]', error)
-    return []
+    return { data: [], total: 0, totalPages: 0, page, pageSize }
   }
 }
 
@@ -163,11 +171,15 @@ export async function getOrdenesProduccionFiltradas({
   estado,
   fechaDesde,
   fechaHasta,
-}: OrdenesProduccionEstadoFechasFilters): Promise<OrdenProduccion[]> {
+  page = 1,
+  pageSize = 25,
+}: OrdenesProduccionEstadoFechasFilters & { page?: number, pageSize?: number }): Promise<PaginatedResponse<OrdenProduccion>> {
   return getOrdenesProduccionPorEstadoYFechas({
     estado,
     fechaDesde,
     fechaHasta,
+    page,
+    pageSize,
   })
 }
 

--- a/src/actions/ordenes.ts
+++ b/src/actions/ordenes.ts
@@ -79,6 +79,7 @@ export interface OrdenesProduccionEstadoFechasFilters {
   estado?: EstadoOrdenProduccion
   fechaDesde?: string
   fechaHasta?: string
+  cod_obra?: number
 }
 
 export type OrdenesProduccionBusquedaAvanzadaFilters =
@@ -93,6 +94,7 @@ async function fetchOrdenesConFiltros(
   if (filters.estado) params.set('estado', filters.estado)
   if (filters.fechaDesde) params.set('fechaDesde', filters.fechaDesde)
   if (filters.fechaHasta) params.set('fechaHasta', filters.fechaHasta)
+  if (filters.cod_obra) params.set('cod_obra', String(filters.cod_obra))
 
   const url = `${BASE_URL}${params.toString() ? `?${params.toString()}` : ''}`
   const token = await getAccessToken()
@@ -133,17 +135,15 @@ export async function getOrdenesProduccionPorEstadoYFechas({
   }
 }
 
-/**
- * Retrieves ordenes for Coordinacion by estado and optional date filters.
- */
 export async function getOrdenesProduccionBusquedaAvanzada({
   estado,
   fechaDesde,
   fechaHasta,
+  cod_obra,
 }: OrdenesProduccionBusquedaAvanzadaFilters): Promise<OrdenProduccion[]> {
   try {
     return await fetchOrdenesConFiltros(
-      { estado, fechaDesde, fechaHasta },
+      { estado, fechaDesde, fechaHasta, cod_obra },
       30,
       ['ordenes-produccion']
     )

--- a/src/actions/ordenes.ts
+++ b/src/actions/ordenes.ts
@@ -435,3 +435,40 @@ export async function updateOrdenProduccion(
     return { success: false, error: message }
   }
 }
+
+/**
+ * Rejects a production order with a reason
+ * @param {number} cod_op - Orden de produccion code/ID
+ * @param {string} motivo - Reason for rejection
+ * @returns {Promise<{success: boolean, data?: OrdenProduccion, error?: string}>} Operation result
+ */
+export async function rejectOrdenProduccion(
+  cod_op: number,
+  motivo: string
+): Promise<ActionResponse<OrdenProduccion>> {
+  try {
+    const token = await getAccessToken()
+    const response = await fetchWithErrorHandling(
+      `${BASE_URL}/${cod_op}/rechazar`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ motivo }),
+      }
+    )
+
+    const data = await response.json()
+    revalidateTag('ordenes-produccion')
+    revalidatePath('/coordinacion/ordenes-produccion')
+    revalidatePath('/produccion')
+
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    console.error('[rejectOrdenProduccion]', message)
+    return { success: false, error: message }
+  }
+}

--- a/src/actions/visitas.ts
+++ b/src/actions/visitas.ts
@@ -279,6 +279,7 @@ export async function createVisitaFromForm(formData: FormData): Promise<ActionRe
       nombre_cliente: (formData.get('nombre') as string) || null,
       apellido_cliente: (formData.get('apellido') as string) || null,
       telefono_cliente: (formData.get('clienteTelefono') as string) || null,
+      cod_ops: formData.get('cod_ops') ? JSON.parse(formData.get('cod_ops') as string) : undefined,
     }
 
     return await createVisita(visitaData)
@@ -318,6 +319,7 @@ export async function updateVisitaFromForm(formData: FormData): Promise<ActionRe
       nombre_cliente: (formData.get('nombre') as string) || null,
       apellido_cliente: (formData.get('apellido') as string) || null,
       telefono_cliente: (formData.get('clienteTelefono') as string) || null,
+      cod_ops: formData.get('cod_ops') ? JSON.parse(formData.get('cod_ops') as string) : undefined,
     }
     return await updateVisita(codVisita, visitaData)
   } catch (error) {

--- a/src/app/(dashboard)/coordinacion/ordenes-produccion/page.tsx
+++ b/src/app/(dashboard)/coordinacion/ordenes-produccion/page.tsx
@@ -18,6 +18,7 @@ export default async function CoordinacionOrdenesPage({
   return (
     <OrdenesPageContent
       estadoInitial={typeof sp.estado === 'string' ? sp.estado : sp.estado?.[0]}
+      page={Number(sp.page) || 1}
     />
   )
 }

--- a/src/app/(dashboard)/coordinacion/prospectos/page.tsx
+++ b/src/app/(dashboard)/coordinacion/prospectos/page.tsx
@@ -1,5 +1,10 @@
-import { getProspectos } from '@/actions/visitas'
-import { ClipboardCheck, MapPin, CalendarPlus } from 'lucide-react'
+﻿import { getProspectos } from '@/actions/visitas'
+import {
+  ClipboardCheck,
+  MapPin,
+  CalendarPlus,
+  ClipboardList,
+} from 'lucide-react'
 import Link from 'next/link'
 import type { SearchParams } from '@/types'
 
@@ -10,7 +15,7 @@ export default async function CoordinacionProspectosPage({
 }) {
   const sp = await searchParams
   const page = Number(typeof sp.page === 'string' ? sp.page : sp.page?.[0]) || 1
-  
+
   // Get PROGRAMADA (pending measurement assignment) prospectos
   const prospectosRes = await getProspectos('PROGRAMADA', page, 25)
   const prospectos = prospectosRes.data
@@ -18,59 +23,81 @@ export default async function CoordinacionProspectosPage({
   return (
     <div className="p-4 sm:p-6 lg:p-8">
       <div className="mx-auto max-w-7xl">
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold text-slate-800">Solicitudes de Medición (Prospectos)</h1>
-          <p className="mt-1 text-sm text-slate-500">
-            Peticiones de Ventas para tomar medidas a nuevos interesados. Asigne fecha, técnico y vehículo.
-          </p>
+        <div className="mb-6 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
+              <ClipboardList className="h-6 w-6 text-blue-600" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                Solicitudes de Medición (Prospectos)
+              </h1>
+              <p className="text-sm text-gray-600">
+                Peticiones de Ventas para tomar medidas a nuevos interesados.
+                Asigne fecha, técnico y vehículo.
+              </p>
+            </div>
+          </div>
         </div>
 
         <div className="grid gap-6">
           {prospectos.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-12 text-center">
               <ClipboardCheck className="mx-auto h-12 w-12 text-slate-400" />
-              <h3 className="mt-4 text-lg font-bold text-slate-800">No hay solicitudes pendientes</h3>
+              <h3 className="mt-4 text-lg font-bold text-slate-800">
+                No hay solicitudes pendientes
+              </h3>
               <p className="mt-1 text-sm text-slate-500">
-                Todas las solicitudes de ventas han sido agendadas o no hay solicitudes nuevas.
+                Todas las solicitudes de ventas han sido agendadas o no hay
+                solicitudes nuevas.
               </p>
             </div>
           ) : (
             prospectos.map((prospecto) => (
               <div
                 key={prospecto.cod_visita}
-                className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md sm:flex-row sm:items-center sm:justify-between"
+                className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-blue-200 hover:shadow-md sm:flex-row sm:items-center sm:justify-between sm:p-5"
               >
-                <div className="space-y-3">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
-                      Pendiente de Agendar
-                    </span>
-                    <span className="text-sm font-bold text-slate-800">
-                      {prospecto.nombre_cliente} {prospecto.apellido_cliente || ''}
-                    </span>
-                  </div>
-                  
-                  <div className="flex flex-col gap-2 text-sm text-slate-500 sm:flex-row sm:items-center sm:gap-6">
-                    <div className="flex items-center gap-1.5">
-                      <MapPin className="h-4 w-4" />
-                      {prospecto.direccion_visita}
-                      {prospecto.localidad && `, ${prospecto.localidad.nombre_localidad}`}
-                    </div>
-                    {prospecto.telefono_cliente && (
-                      <div className="flex items-center gap-1.5">
-                        <span className="font-semibold text-slate-600">Tel:</span> {prospecto.telefono_cliente}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="truncate text-base font-semibold text-gray-900 sm:text-lg">
+                          {prospecto.nombre_cliente}{' '}
+                          {prospecto.apellido_cliente || ''}
+                        </h3>
+                        <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700">
+                          Pendiente de Agendar
+                        </span>
                       </div>
-                    )}
+
+                      <div className="mt-2 flex flex-col gap-2 text-sm text-gray-600 sm:flex-row sm:items-center sm:gap-6">
+                        <div className="flex items-center gap-1.5">
+                          <MapPin className="h-4 w-4 text-gray-500" />
+                          {prospecto.direccion_visita}
+                          {prospecto.localidad &&
+                            `, ${prospecto.localidad.nombre_localidad}`}
+                        </div>
+                        {prospecto.telefono_cliente && (
+                          <div className="flex items-center gap-1.5">
+                            <span className="font-semibold text-slate-600">
+                              Tel:
+                            </span>{' '}
+                            {prospecto.telefono_cliente}
+                          </div>
+                        )}
+                      </div>
+                    </div>
                   </div>
                 </div>
 
-                <div className="flex shrink-0 gap-3">
+                <div className="mt-4 flex flex-wrap items-center gap-2 sm:mt-0 sm:justify-end">
                   <Link
                     href={`/coordinacion/visitas/${prospecto.cod_visita}/editar`}
-                    className="flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-blue-700"
+                    className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3.5 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
                   >
                     <CalendarPlus className="h-4 w-4" />
-                    AGENDAR VISITA
+                    Agendar visita
                   </Link>
                 </div>
               </div>

--- a/src/app/(dashboard)/ventas/prospectos/page.tsx
+++ b/src/app/(dashboard)/ventas/prospectos/page.tsx
@@ -1,7 +1,15 @@
-import { getProspectos } from '@/actions/visitas'
+﻿import { getProspectos } from '@/actions/visitas'
 import { getProvincias } from '@/actions/localidad'
 import SolicitarMedicionModal from '@/components/ventas/prospectos/SolicitarMedicionModal'
-import { Plus, MapPin, Calendar, ClipboardCheck } from 'lucide-react'
+import {
+  Plus,
+  MapPin,
+  Calendar,
+  ClipboardCheck,
+  ClipboardList,
+  UserPlus,
+  FileText,
+} from 'lucide-react'
 import Link from 'next/link'
 import type { SearchParams } from '@/types'
 
@@ -13,7 +21,7 @@ export default async function ProspectosPage({
   const sp = await searchParams
   const page = Number(typeof sp.page === 'string' ? sp.page : sp.page?.[0]) || 1
   const provincias = await getProvincias()
-  
+
   // We want to see both PROGRAMADA (pending measurement) and COMPLETADA (ready to create Obra)
   // Let's get them by status or all.
   const prospectosRes = await getProspectos('ALL', page, 25)
@@ -22,12 +30,19 @@ export default async function ProspectosPage({
   return (
     <div className="p-4 sm:p-6 lg:p-8">
       <div className="mx-auto max-w-7xl">
-        <div className="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-          <div>
-            <h1 className="text-2xl font-bold text-slate-800">Bandeja de Prospectos</h1>
-            <p className="mt-1 text-sm text-slate-500">
-              Gestione las solicitudes de medición para potenciales clientes
-            </p>
+        <div className="mb-6 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
+              <ClipboardList className="h-6 w-6 text-blue-600" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                Bandeja de Prospectos
+              </h1>
+              <p className="text-sm text-gray-600">
+                Gestione las solicitudes de medición para potenciales clientes
+              </p>
+            </div>
           </div>
           <SolicitarMedicionModal provincias={provincias} />
         </div>
@@ -36,7 +51,9 @@ export default async function ProspectosPage({
           {prospectos.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-12 text-center">
               <ClipboardCheck className="mx-auto h-12 w-12 text-slate-400" />
-              <h3 className="mt-4 text-lg font-bold text-slate-800">No hay prospectos activos</h3>
+              <h3 className="mt-4 text-lg font-bold text-slate-800">
+                No hay prospectos activos
+              </h3>
               <p className="mt-1 text-sm text-slate-500">
                 Las solicitudes de medición aparecerán aquí.
               </p>
@@ -45,68 +62,86 @@ export default async function ProspectosPage({
             prospectos.map((prospecto) => (
               <div
                 key={prospecto.cod_visita}
-                className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md sm:flex-row sm:items-center sm:justify-between"
+                className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-blue-200 hover:shadow-md sm:flex-row sm:items-center sm:justify-between sm:p-5"
               >
-                <div className="space-y-3">
-                  <div className="flex items-center gap-3">
-                    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
-                      prospecto.estado === 'COMPLETADA' 
-                        ? 'bg-green-100 text-green-800'
-                        : prospecto.estado === 'PROGRAMADA' 
-                        ? 'bg-yellow-100 text-yellow-800'
-                        : 'bg-slate-100 text-slate-800'
-                    }`}>
-                      {prospecto.estado === 'COMPLETADA' ? 'Medición Lista' : 'Pendiente de Medición'}
-                    </span>
-                    <span className="text-sm font-bold text-slate-800">
-                      {prospecto.nombre_cliente} {prospecto.apellido_cliente || ''}
-                    </span>
-                  </div>
-                  
-                  <div className="flex flex-col gap-2 text-sm text-slate-500 sm:flex-row sm:items-center sm:gap-6">
-                    <div className="flex items-center gap-1.5">
-                      <MapPin className="h-4 w-4" />
-                      {prospecto.direccion_visita}
-                      {prospecto.localidad && `, ${prospecto.localidad.nombre_localidad}`}
-                    </div>
-                    {prospecto.fecha_hora_visita && (
-                      <div className="flex items-center gap-1.5">
-                        <Calendar className="h-4 w-4" />
-                        Agendado para: {new Date(prospecto.fecha_hora_visita).toLocaleDateString()}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="truncate text-base font-semibold text-gray-900 sm:text-lg">
+                          {prospecto.nombre_cliente}{' '}
+                          {prospecto.apellido_cliente || ''}
+                        </h3>
+                        <span
+                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
+                            prospecto.estado === 'COMPLETADA'
+                              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                              : prospecto.estado === 'PROGRAMADA'
+                                ? 'border-amber-200 bg-amber-50 text-amber-700'
+                                : 'border-slate-200 bg-slate-50 text-slate-700'
+                          }`}
+                        >
+                          {prospecto.estado === 'COMPLETADA'
+                            ? 'Medición Lista'
+                            : 'Pendiente de Medición'}
+                        </span>
                       </div>
-                    )}
-                  </div>
 
-                  {prospecto.estado === 'COMPLETADA' && prospecto.observaciones && (
-                    <details className="group rounded-lg bg-slate-50 p-3 text-sm text-slate-700 open:bg-white open:ring-1 open:ring-slate-200 transition-all">
-                      <summary className="cursor-pointer font-semibold text-blue-600 hover:text-blue-700 select-none">Ver Detalles de Medición</summary>
-                      <div className="mt-3 whitespace-pre-wrap text-slate-600 pl-1 border-l-2 border-blue-200">
-                        {prospecto.observaciones}
+                      <div className="mt-2 flex flex-col gap-2 text-sm text-gray-600 sm:flex-row sm:items-center sm:gap-6">
+                        <div className="flex items-center gap-1.5">
+                          <MapPin className="h-4 w-4 text-gray-500" />
+                          {prospecto.direccion_visita}
+                          {prospecto.localidad &&
+                            `, ${prospecto.localidad.nombre_localidad}`}
+                        </div>
+                        {prospecto.fecha_hora_visita && (
+                          <div className="flex items-center gap-1.5">
+                            <Calendar className="h-4 w-4 text-gray-500" />
+                            Agendado para:{' '}
+                            {new Date(
+                              prospecto.fecha_hora_visita
+                            ).toLocaleDateString()}
+                          </div>
+                        )}
                       </div>
-                    </details>
-                  )}
+
+                      {prospecto.estado === 'COMPLETADA' &&
+                        prospecto.observaciones && (
+                          <div className="mt-3">
+                            <details className="group rounded-lg bg-slate-50 p-3 text-sm text-slate-700 transition-all open:bg-white open:ring-1 open:ring-slate-200">
+                              <summary className="cursor-pointer font-semibold text-blue-600 select-none hover:text-blue-700">
+                                Ver detalles de medición
+                              </summary>
+                              <div className="mt-3 border-l-2 border-blue-200 pl-1 whitespace-pre-wrap text-slate-600">
+                                {prospecto.observaciones}
+                              </div>
+                            </details>
+                          </div>
+                        )}
+                    </div>
+                  </div>
                 </div>
 
-                <div className="flex shrink-0 gap-3">
+                <div className="mt-4 flex flex-wrap items-center gap-2 sm:mt-0 sm:justify-end">
                   {prospecto.estado === 'COMPLETADA' ? (
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2">
                       <Link
                         href={`/ventas/clientes/crear?nombre=${encodeURIComponent((prospecto.nombre_cliente || '') + ' ' + (prospecto.apellido_cliente || ''))}&telefono=${encodeURIComponent(prospecto.telefono_cliente || '')}`}
-                        className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-blue-600 transition-colors hover:bg-slate-50"
+                        className="inline-flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 px-3.5 py-2 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-100"
                       >
-                        <Plus className="h-4 w-4" />
-                        CREAR CLIENTE
+                        <UserPlus className="h-4 w-4" />
+                        Crear cliente
                       </Link>
                       <Link
                         href={`/ventas/obras/crear?prospecto=${prospecto.cod_visita}`}
-                        className="flex items-center gap-2 rounded-xl bg-green-600 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-green-700"
+                        className="inline-flex items-center gap-2 rounded-lg border border-emerald-300 bg-emerald-50 px-3.5 py-2 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100"
                       >
-                        <Plus className="h-4 w-4" />
-                        GENERAR OBRA
+                        <FileText className="h-4 w-4" />
+                        Generar obra
                       </Link>
                     </div>
                   ) : (
-                    <span className="text-sm font-medium text-slate-400">
+                    <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-sm font-medium text-slate-500">
                       Esperando a Coordinación...
                     </span>
                   )}

--- a/src/components/coordinacion/CrearVisita.tsx
+++ b/src/components/coordinacion/CrearVisita.tsx
@@ -14,6 +14,7 @@ import { MOTIVOS_VISITA_OPTIONS } from '@/constants'
 import useVisitaForm from '@/hooks/useVisitaForm'
 import VisitaUbicacionSeccion from './visita/VisitaUbicacionSeccion'
 import VisitaLogisticaSeccion from './visita/VisitaLogisticaSeccion'
+import VisitaOPSelection from './visita/VisitaOPSelection'
 
 /**
  * Form for scheduling or editing a visit (visita).
@@ -63,6 +64,10 @@ export default function CrearVisita({
     getEmpleadoNombre,
     handleLoadLocalidades,
     handleSubmit,
+    selectedOps,
+    setSelectedOps,
+    eligibleOps,
+    isLoadingOps,
     viaticoPorDia,
     totalViaticos,
   } = useVisitaForm({ preloadedObra, visitaEditar, empleados, provincias, buscarLocalidades })
@@ -106,6 +111,13 @@ export default function CrearVisita({
             loadingLocalidades={loadingLocalidades}
             handleLoadLocalidades={handleLoadLocalidades}
             buscarObras={buscarObras}
+          />
+
+          <VisitaOPSelection
+            eligibleOps={eligibleOps}
+            selectedOps={selectedOps}
+            onChange={setSelectedOps}
+            isLoading={isLoadingOps}
           />
 
           {/* Section: Motivo y Coordinación */}

--- a/src/components/coordinacion/orden_produccion/MedicionesVisitaModal.tsx
+++ b/src/components/coordinacion/orden_produccion/MedicionesVisitaModal.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { X, FileText, Ruler, MapPin, Calendar, User } from 'lucide-react'
+import type { Visita } from '@/types'
+
+interface MedicionesVisitaModalProps {
+  isOpen: boolean
+  onClose: () => void
+  visita: Visita
+}
+
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString('es-AR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function MedicionesVisitaModal({
+  isOpen,
+  onClose,
+  visita,
+}: MedicionesVisitaModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-lg rounded-2xl bg-white shadow-2xl ring-1 ring-black/5 animate-in fade-in zoom-in duration-200">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-100 p-6">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100">
+              <Ruler className="h-5 w-5 text-indigo-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-slate-800">Mediciones Técnicas</h2>
+              <p className="text-xs text-slate-500">Visita #{visita.cod_visita}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-6">
+          {/* Metadata Grid */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
+                <Calendar className="h-3 w-3" />
+                Fecha
+              </div>
+              <p className="text-sm font-medium text-slate-700">{formatDate(visita.fecha_hora_visita)}</p>
+            </div>
+            <div className="space-y-1">
+              <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
+                <MapPin className="h-3 w-3" />
+                Lugar
+              </div>
+              <p className="text-sm font-medium text-slate-700 truncate">{visita.direccion_visita || 'Obra'}</p>
+            </div>
+          </div>
+
+          {/* Visitadores */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
+              <User className="h-3 w-3" />
+              Personal Técnico
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {visita.empleado_visita && visita.empleado_visita.length > 0 ? (
+                visita.empleado_visita.map((ev) => (
+                  <span key={ev.cuil} className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600 border border-slate-200">
+                    {ev.empleado?.nombre} {ev.empleado?.apellido}
+                  </span>
+                ))
+              ) : (
+                <span className="text-xs text-slate-400 italic">No se asignó personal técnico</span>
+              )}
+            </div>
+          </div>
+
+          {/* Observations / Measurements */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
+              <FileText className="h-3 w-3" />
+              Observaciones y Medidas
+            </div>
+            <div className="rounded-xl border border-slate-100 bg-slate-50/50 p-4">
+              {visita.observaciones ? (
+                <p className="whitespace-pre-wrap text-sm text-slate-600 leading-relaxed italic">
+                  "{visita.observaciones}"
+                </p>
+              ) : (
+                <p className="text-sm text-slate-400 italic">No se registraron observaciones detalladas.</p>
+              )}
+            </div>
+          </div>
+          
+          <div className="bg-amber-50 border border-amber-100 rounded-xl p-4">
+             <p className="text-xs text-amber-800 leading-normal">
+               <b>Nota:</b> Estas medidas fueron validadas en terreno y sirven como base técnica para la orden de producción actual.
+             </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-slate-100 bg-slate-50/50 p-4 rounded-b-2xl text-right">
+          <button
+            onClick={onClose}
+            className="rounded-xl bg-slate-800 px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-slate-200 transition-all hover:bg-slate-700 hover:shadow-xl active:scale-95"
+          >
+            Entendido
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/coordinacion/orden_produccion/MedicionesVisitaModal.tsx
+++ b/src/components/coordinacion/orden_produccion/MedicionesVisitaModal.tsx
@@ -96,7 +96,7 @@ export default function MedicionesVisitaModal({
             <div className="rounded-xl border border-slate-100 bg-slate-50/50 p-4">
               {visita.observaciones ? (
                 <p className="whitespace-pre-wrap text-sm text-slate-600 leading-relaxed italic">
-                  "{visita.observaciones}"
+                  &quot;{visita.observaciones}&quot;
                 </p>
               ) : (
                 <p className="text-sm text-slate-400 italic">No se registraron observaciones detalladas.</p>

--- a/src/components/coordinacion/orden_produccion/OPConfirmModal.tsx
+++ b/src/components/coordinacion/orden_produccion/OPConfirmModal.tsx
@@ -32,6 +32,11 @@ export default function OPConfirmModal({
     }
   }
 
+  const visitCompletada = orden.visita?.estado === 'COMPLETADA'
+  const hasVisitasObra = orden.obra?.visita?.some((v) => v.estado === 'COMPLETADA')
+  
+  const showWarning = !visitCompletada
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
       <div className="w-full max-w-md rounded-xl bg-white shadow-2xl">
@@ -69,7 +74,7 @@ export default function OPConfirmModal({
             </div>
           </div>
 
-          {!orden.obra?.visita?.some((v) => v.estado === 'COMPLETADA') && (
+          {showWarning && (
             <div className="mb-4 flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 p-4">
               <AlertCircle className="h-5 w-5 flex-shrink-0 text-yellow-600" />
               <div>
@@ -77,9 +82,10 @@ export default function OPConfirmModal({
                   Falta visita de medición
                 </p>
                 <p className="mt-1 text-sm text-yellow-800">
-                  Esta obra no tiene ninguna visita de medición completada.
-                  Si aprueba la orden sin medidas verificadas, Producción
-                  podría fabricar basándose solo en el presupuesto inicial.
+                  {hasVisitasObra 
+                    ? 'Esta orden no tiene vinculada la visita de medición completada. Se recomienda vincularla para asegurar la precisión de la producción.'
+                    : 'Esta obra no tiene ninguna visita de medición completada. Producción podría fabricar basándose solo en el presupuesto inicial.'
+                  }
                 </p>
               </div>
             </div>

--- a/src/components/coordinacion/orden_produccion/OrdenProduccionCard.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenProduccionCard.tsx
@@ -145,7 +145,7 @@ export default function OrdenProduccionCard({
               Ver Detalles
             </button>
 
-            {(orden.estado === 'PENDIENTE' || orden.estado === 'RECHAZADA') && (
+            {orden.estado === 'PENDIENTE' && (
               <div className="flex gap-2">
                 <button
                   onClick={handleAprobar}
@@ -155,16 +155,14 @@ export default function OrdenProduccionCard({
                   <CheckCircle className="h-4 w-4" />
                   {isApproving ? 'Aprobando...' : 'Aprobar'}
                 </button>
-                
-                {orden.estado === 'PENDIENTE' && (
-                  <button
-                    onClick={handleRechazar}
-                    className="flex items-center gap-2 rounded-lg border border-red-200 bg-white px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
-                  >
-                    <XCircle className="h-4 w-4" />
-                    Rechazar
-                  </button>
-                )}
+
+                <button
+                  onClick={handleRechazar}
+                  className="flex items-center gap-2 rounded-lg border border-red-200 bg-white px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
+                >
+                  <XCircle className="h-4 w-4" />
+                  Rechazar
+                </button>
               </div>
             )}
 

--- a/src/components/coordinacion/orden_produccion/OrdenProduccionCard.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenProduccionCard.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import type { OrdenProduccion } from '@/types'
-import { MapPin, Package, Calendar, Eye, CheckCircle, CalendarPlus } from 'lucide-react'
+import { MapPin, Package, Calendar, Eye, CheckCircle, CalendarPlus, XCircle } from 'lucide-react'
 
 interface OrdenProduccionCardProps {
   orden: OrdenProduccion
   onVerDetalles: (orden: OrdenProduccion) => void
   onAprobar: (orden: OrdenProduccion) => void
+  onRechazar: (orden: OrdenProduccion) => void
 }
 
 const formatDate = (dateString: string) =>
@@ -26,6 +27,8 @@ const getEstadoBadgeColor = (estado: string) => {
       return 'bg-green-500'
     case 'FINALIZADA':
       return 'bg-gray-500'
+    case 'RECHAZADA':
+      return 'bg-red-500'
     default:
       return 'bg-gray-400'
   }
@@ -35,6 +38,7 @@ export default function OrdenProduccionCard({
   orden,
   onVerDetalles,
   onAprobar,
+  onRechazar,
 }: OrdenProduccionCardProps) {
   const [isApproving, setIsApproving] = useState(false)
   const cliente = orden.obra?.cliente
@@ -51,6 +55,11 @@ export default function OrdenProduccionCard({
     } finally {
       setIsApproving(false)
     }
+  }
+
+  const handleRechazar = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onRechazar(orden)
   }
 
   const handleVerDetalles = (e: React.MouseEvent) => {
@@ -136,15 +145,27 @@ export default function OrdenProduccionCard({
               Ver Detalles
             </button>
 
-            {orden.estado === 'PENDIENTE' && (
-              <button
-                onClick={handleAprobar}
-                disabled={isApproving}
-                className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <CheckCircle className="h-4 w-4" />
-                {isApproving ? 'Aprobando...' : 'Aprobar'}
-              </button>
+            {(orden.estado === 'PENDIENTE' || orden.estado === 'RECHAZADA') && (
+              <div className="flex gap-2">
+                <button
+                  onClick={handleAprobar}
+                  disabled={isApproving}
+                  className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <CheckCircle className="h-4 w-4" />
+                  {isApproving ? 'Aprobando...' : 'Aprobar'}
+                </button>
+                
+                {orden.estado === 'PENDIENTE' && (
+                  <button
+                    onClick={handleRechazar}
+                    className="flex items-center gap-2 rounded-lg border border-red-200 bg-white px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
+                  >
+                    <XCircle className="h-4 w-4" />
+                    Rechazar
+                  </button>
+                )}
+              </div>
             )}
 
             {!orden.cod_visita && (

--- a/src/components/coordinacion/orden_produccion/OrdenProduccionCard.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenProduccionCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
+import Link from 'next/link'
 import type { OrdenProduccion } from '@/types'
-import { MapPin, Package, Calendar, Eye, CheckCircle } from 'lucide-react'
+import { MapPin, Package, Calendar, Eye, CheckCircle, CalendarPlus } from 'lucide-react'
 
 interface OrdenProduccionCardProps {
   orden: OrdenProduccion
@@ -107,12 +108,13 @@ export default function OrdenProduccionCard({
 
           {/* Estado de Visitas */}
           <div className="pt-1">
-            {orden.obra?.visita?.some((v) => v.estado === 'COMPLETADA') ? (
+            {orden.visita?.estado === 'COMPLETADA' ? (
               <span className="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
                 Visita completada
               </span>
-            ) : orden.obra?.visita?.some(
-                (v) => v.estado === 'PROGRAMADA' || v.estado === 'EN CURSO'
+            ) : orden.visita &&
+              ['PROGRAMADA', 'EN CURSO', 'REPROGRAMADA'].includes(
+                orden.visita.estado || ''
               ) ? (
               <span className="inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">
                 Visita pendiente
@@ -143,6 +145,16 @@ export default function OrdenProduccionCard({
                 <CheckCircle className="h-4 w-4" />
                 {isApproving ? 'Aprobando...' : 'Aprobar'}
               </button>
+            )}
+
+            {!orden.cod_visita && (
+              <Link
+                href={`/coordinacion/visitas/crear?cod_obra=${orden.cod_obra}&cod_op=${orden.cod_op}`}
+                className="flex items-center gap-2 rounded-lg border border-indigo-600 bg-white px-4 py-2 text-sm font-medium text-indigo-600 transition-colors hover:bg-indigo-50"
+              >
+                <CalendarPlus className="h-4 w-4" />
+                Agendar Visita
+              </Link>
             )}
           </div>
         </div>

--- a/src/components/coordinacion/orden_produccion/OrdenProduccionDetailsModal.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenProduccionDetailsModal.tsx
@@ -16,6 +16,7 @@ import {
 import type { OrdenProduccion } from '@/types'
 import PDFViewerModal from './PDFViewerModal'
 import MedicionesVisitaModal from './MedicionesVisitaModal'
+import { AlertCircle } from 'lucide-react'
 
 interface OrdenProduccionDetailsModalProps {
   isOpen: boolean
@@ -61,6 +62,13 @@ const getEstadoInfo = (estado: string) => {
         textColor: 'text-gray-700',
         borderColor: 'border-gray-200',
         badgeColor: 'bg-gray-500',
+      }
+    case 'RECHAZADA':
+      return {
+        bgColor: 'bg-red-50',
+        textColor: 'text-red-700',
+        borderColor: 'border-red-200',
+        badgeColor: 'bg-red-500',
       }
     default:
       return {
@@ -129,6 +137,23 @@ export default function OrdenProduccionDetailsModal({
         {/* Content */}
         <div className="p-6">
           <div className="space-y-6">
+            {/* Alerta de Rechazo */}
+            {orden.estado === 'RECHAZADA' && (
+              <div className="rounded-xl border border-red-200 bg-red-50 p-4 shadow-sm ring-1 ring-red-100">
+                <div className="flex gap-3">
+                  <div className="rounded-lg bg-red-100 p-2 h-fit">
+                    <AlertCircle className="h-5 w-5 text-red-600" />
+                  </div>
+                  <div>
+                    <h4 className="font-bold text-red-900">Orden Rechazada</h4>
+                    <p className="mt-1 text-sm text-red-800 leading-relaxed">
+                      {orden.motivo_rechazo || 'No se proporcionó un motivo específico.'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* Estado */}
             <div>
               <label className="mb-2 block text-sm font-medium text-gray-700">

--- a/src/components/coordinacion/orden_produccion/OrdenProduccionDetailsModal.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenProduccionDetailsModal.tsx
@@ -11,9 +11,11 @@ import {
   Building2,
   Eye,
   ExternalLink,
+  Info,
 } from 'lucide-react'
 import type { OrdenProduccion } from '@/types'
 import PDFViewerModal from './PDFViewerModal'
+import MedicionesVisitaModal from './MedicionesVisitaModal'
 
 interface OrdenProduccionDetailsModalProps {
   isOpen: boolean
@@ -76,6 +78,7 @@ export default function OrdenProduccionDetailsModal({
   onClose,
 }: OrdenProduccionDetailsModalProps) {
   const [isPDFModalOpen, setIsPDFModalOpen] = useState(false)
+  const [isMedicionesModalOpen, setIsMedicionesModalOpen] = useState(false)
 
   if (!isOpen || !orden) return null
 
@@ -207,6 +210,45 @@ export default function OrdenProduccionDetailsModal({
               </div>
             </div>
 
+            {/* Visita Vinculada */}
+            <div>
+              <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
+                <Calendar className="h-4 w-4" />
+                Visita de Medición
+              </label>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                {orden.visita ? (
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className={`h-2 w-2 rounded-full ${orden.visita.estado === 'COMPLETADA' ? 'bg-green-500' : 'bg-yellow-500'}`} />
+                        <p className="text-sm font-medium text-gray-900">
+                          Visita #{orden.visita.cod_visita} - {orden.visita.estado}
+                        </p>
+                      </div>
+                      <p className="mt-1 text-xs text-gray-500">
+                        {formatDate(orden.visita.fecha_hora_visita)}
+                      </p>
+                    </div>
+                    {orden.visita.estado === 'COMPLETADA' && (
+                      <button
+                        onClick={() => setIsMedicionesModalOpen(true)}
+                        className="flex items-center justify-center gap-2 rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700 transition-colors hover:bg-indigo-100"
+                      >
+                        <Info className="h-4 w-4" />
+                        Ver Mediciones
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 text-gray-500">
+                    <Info className="h-4 w-4" />
+                    <p className="text-sm">No hay una visita vinculada a esta orden.</p>
+                  </div>
+                )}
+              </div>
+            </div>
+
             {/* Información del Cliente */}
             <div>
               <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
@@ -300,6 +342,15 @@ export default function OrdenProduccionDetailsModal({
           onClose={() => setIsPDFModalOpen(false)}
           pdfUrl={orden.url}
           title={`Orden de Producción #${orden.cod_op}`}
+        />
+      )}
+
+      {/* Modal de Mediciones */}
+      {orden.visita && (
+        <MedicionesVisitaModal
+          isOpen={isMedicionesModalOpen}
+          onClose={() => setIsMedicionesModalOpen(false)}
+          visita={orden.visita}
         />
       )}
     </div>

--- a/src/components/coordinacion/orden_produccion/OrdenesProduccionContent.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenesProduccionContent.tsx
@@ -38,7 +38,7 @@ export default function OrdenesProduccionContent({
 
   // Filtros
   const [filtroEstado, setFiltroEstado] = useState<string>(
-    searchParams.get('estado') || ESTADOS_ORDEN_PRODUCCION[0]
+    searchParams.get('estado') || ''
   )
   const [filtroCliente, setFiltroCliente] = useState<string>('')
 
@@ -68,6 +68,8 @@ export default function OrdenesProduccionContent({
     } else {
       params.delete('estado')
     }
+    // Reset page when filters change
+    params.delete('page')
     router.push(`?${params.toString()}`)
   }
 

--- a/src/components/coordinacion/orden_produccion/OrdenesProduccionContent.tsx
+++ b/src/components/coordinacion/orden_produccion/OrdenesProduccionContent.tsx
@@ -10,6 +10,7 @@ import { notify } from '@/lib/toast'
 import OrdenProduccionCard from './OrdenProduccionCard'
 import OrdenProduccionDetailsModal from './OrdenProduccionDetailsModal'
 import OPConfirmModal from './OPConfirmModal'
+import RechazarOPModal from './RechazarOPModal'
 
 interface OrdenesProduccionContentProps {
   ordenes: OrdenProduccion[]
@@ -29,7 +30,11 @@ export default function OrdenesProduccionContent({
   const [ordenToApprove, setOrdenToApprove] = useState<OrdenProduccion | null>(
     null
   )
+  const [ordenToReject, setOrdenToReject] = useState<OrdenProduccion | null>(
+    null
+  )
   const [isApproving, setIsApproving] = useState(false)
+  const [isRechazarModalOpen, setIsRechazarModalOpen] = useState(false)
 
   // Filtros
   const [filtroEstado, setFiltroEstado] = useState<string>(
@@ -96,6 +101,11 @@ export default function OrdenesProduccionContent({
   const handleAprobar = (orden: OrdenProduccion) => {
     setOrdenToApprove(orden)
     setIsConfirmModalOpen(true)
+  }
+
+  const handleRechazar = (orden: OrdenProduccion) => {
+    setOrdenToReject(orden)
+    setIsRechazarModalOpen(true)
   }
 
   const handleVerDetalles = (orden: OrdenProduccion) => {
@@ -185,6 +195,7 @@ export default function OrdenesProduccionContent({
               orden={orden}
               onVerDetalles={handleVerDetalles}
               onAprobar={handleAprobar}
+              onRechazar={handleRechazar}
             />
           ))}
         </div>
@@ -208,6 +219,19 @@ export default function OrdenesProduccionContent({
         }}
         loading={isApproving}
       />
+
+      {/* Modal de Rechazo */}
+      {ordenToReject && (
+        <RechazarOPModal
+          isOpen={isRechazarModalOpen}
+          onClose={() => {
+            setIsRechazarModalOpen(false)
+            setOrdenToReject(null)
+            router.refresh()
+          }}
+          cod_op={ordenToReject.cod_op}
+        />
+      )}
     </>
   )
 }

--- a/src/components/coordinacion/orden_produccion/RechazarOPModal.tsx
+++ b/src/components/coordinacion/orden_produccion/RechazarOPModal.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { X, AlertCircle, Loader2 } from 'lucide-react'
+import { rejectOrdenProduccion } from '@/actions/ordenes'
+import { notify } from '@/lib/toast'
+
+interface RechazarOPModalProps {
+  isOpen: boolean
+  onClose: () => void
+  cod_op: number
+}
+
+export default function RechazarOPModal({ isOpen, onClose, cod_op }: RechazarOPModalProps) {
+  const [motivo, setMotivo] = useState('')
+  const [isPending, startTransition] = useTransition()
+
+  if (!isOpen) return null
+
+  const handleConfirm = () => {
+    if (!motivo.trim()) {
+      notify.error('Debe proporcionar un motivo para el rechazo.')
+      return
+    }
+
+    startTransition(async () => {
+      const res = await rejectOrdenProduccion(cod_op, motivo)
+      if (res.success) {
+        notify.success('Orden rechazada correctamente.')
+        onClose()
+      } else {
+        notify.error(res.error || 'Error al rechazar la orden.')
+      }
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      <div 
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" 
+        onClick={onClose}
+      />
+      <div className="relative w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-2xl ring-1 ring-slate-200">
+        <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50/50 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-red-100 p-2">
+              <AlertCircle className="h-5 w-5 text-red-600" />
+            </div>
+            <h3 className="font-bold text-slate-800">Rechazar Orden</h3>
+          </div>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-600 transition-colors">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <p className="text-sm text-slate-600">
+            Explique el motivo del rechazo. Esta información será visible para el equipo de producción para que puedan corregir la orden.
+          </p>
+          
+          <div>
+            <label className="mb-2 block text-xs font-bold uppercase tracking-wider text-slate-500">
+              Motivo del rechazo *
+            </label>
+            <textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              className="w-full min-h-[120px] rounded-xl border border-slate-200 p-4 text-sm focus:border-red-500 focus:outline-none focus:ring-4 focus:ring-red-500/10 placeholder:text-slate-400"
+              placeholder="Ej: Las medidas no coinciden con la visita del 05/05..."
+              autoFocus
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-slate-100 bg-slate-50/50 px-6 py-4">
+          <button
+            onClick={onClose}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-semibold text-slate-600 hover:text-slate-800 transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isPending}
+            className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-6 py-2 text-sm font-bold text-white shadow-md hover:bg-red-700 transition-all disabled:opacity-50"
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              'Confirmar Rechazo'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/coordinacion/visita/VisitaOPSelection.tsx
+++ b/src/components/coordinacion/visita/VisitaOPSelection.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { CheckSquare, Square, Info } from 'lucide-react'
+import type { OrdenProduccion } from '@/types'
+
+interface VisitaOPSelectionProps {
+  eligibleOps: OrdenProduccion[]
+  selectedOps: number[]
+  onChange: (selected: number[]) => void
+  isLoading?: boolean
+}
+
+export default function VisitaOPSelection({
+  eligibleOps,
+  selectedOps,
+  onChange,
+  isLoading = false,
+}: VisitaOPSelectionProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-600 border-t-transparent"></div>
+        <span className="ml-3 text-sm text-slate-500">Cargando órdenes de producción...</span>
+      </div>
+    )
+  }
+
+  if (eligibleOps.length === 0) return null
+
+  const toggleOp = (cod_op: number) => {
+    if (selectedOps.includes(cod_op)) {
+      onChange(selectedOps.filter((id) => id !== cod_op))
+    } else {
+      onChange([...selectedOps, cod_op])
+    }
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-200/60 bg-white shadow-sm ring-1 ring-slate-100 transition-all hover:shadow-md">
+      <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50/50 px-5 py-4">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-indigo-100/80 p-2 shadow-inner">
+            <CheckSquare className="h-5 w-5 text-indigo-600" />
+          </div>
+          <h3 className="font-semibold text-slate-800">Órdenes de Producción a Validar</h3>
+        </div>
+        <span className="text-xs font-medium text-slate-400 bg-white px-2 py-1 rounded-full border border-slate-100">
+          {selectedOps.length} seleccionadas
+        </span>
+      </div>
+      
+      <div className="p-5">
+        <p className="text-sm text-slate-500 mb-4 flex items-start gap-2">
+          <Info className="h-4 w-4 mt-0.5 text-blue-500 flex-shrink-0" />
+          Seleccione las órdenes de producción que serán verificadas durante esta visita técnica.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {eligibleOps.map((op) => {
+            const isSelected = selectedOps.includes(op.cod_op)
+            return (
+              <button
+                key={op.cod_op}
+                type="button"
+                onClick={() => toggleOp(op.cod_op)}
+                className={`flex items-center gap-3 p-3 rounded-xl border transition-all text-left ${
+                  isSelected
+                    ? 'border-indigo-500 bg-indigo-50/50 ring-1 ring-indigo-500/20 shadow-sm'
+                    : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50'
+                }`}
+              >
+                <div className={`flex-shrink-0 ${isSelected ? 'text-indigo-600' : 'text-slate-300'}`}>
+                  {isSelected ? <CheckSquare className="h-5 w-5" /> : <Square className="h-5 w-5" />}
+                </div>
+                <div className="min-w-0 flex-grow">
+                  <p className={`text-sm font-bold truncate ${isSelected ? 'text-indigo-900' : 'text-slate-700'}`}>
+                    Orden #{op.cod_op}
+                  </p>
+                  <p className="text-xs text-slate-500 truncate">
+                    {op.obra?.direccion || 'Sin dirección'}
+                  </p>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pages/OrdenesPageContent.tsx
+++ b/src/components/pages/OrdenesPageContent.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { ClipboardList } from 'lucide-react'
 import { getOrdenesProduccion } from '@/actions/ordenes'
 import OrdenesProduccionContent from '@/components/coordinacion/orden_produccion/OrdenesProduccionContent'
+import PaginationControls from '@/components/shared/PaginationControls'
 import type { EstadoOrdenProduccion } from '@/types'
 
 function OrdenesListSkeleton() {
@@ -33,11 +34,19 @@ function OrdenesListSkeleton() {
   )
 }
 
-async function OrdenesGrid({ estado }: { estado?: string }) {
+async function OrdenesGrid({
+  estado,
+  page,
+  pageSize
+}: {
+  estado?: string,
+  page: number,
+  pageSize: number
+}) {
   // Ajustamos el estado para que coincida con lo que espera la acción
   const estadoFilter = estado as EstadoOrdenProduccion | undefined
 
-  const result = await getOrdenesProduccion({ estado: estadoFilter })
+  const result = await getOrdenesProduccion({ estado: estadoFilter }, page, pageSize)
 
   if (!result.success) {
     return (
@@ -49,15 +58,33 @@ async function OrdenesGrid({ estado }: { estado?: string }) {
     )
   }
 
-  return <OrdenesProduccionContent ordenes={result.data || []} />
+  const paginatedResult = result.data
+
+  return (
+    <>
+      <OrdenesProduccionContent ordenes={paginatedResult?.data || []} />
+      <div className="mt-8">
+        <PaginationControls
+          page={paginatedResult?.page || 1}
+          totalPages={paginatedResult?.totalPages || 1}
+          total={paginatedResult?.total || 0}
+          pageSize={paginatedResult?.pageSize || 25}
+        />
+      </div>
+    </>
+  )
 }
 
 interface OrdenesPageContentProps {
   estadoInitial?: string
+  page?: number
+  pageSize?: number
 }
 
 export default async function OrdenesPageContent({
-  estadoInitial = 'PENDIENTE',
+  estadoInitial = '',
+  page = 1,
+  pageSize = 10,
 }: OrdenesPageContentProps) {
   // El filtro 'estadoInitial' lo usa el componente cliente para su estado por defecto
   // y nosotros para la búsqueda inicial en el servidor.
@@ -83,8 +110,15 @@ export default async function OrdenesPageContent({
         </div>
 
         {/* Listado con Suspense */}
-        <Suspense key={estadoInitial} fallback={<OrdenesListSkeleton />}>
-          <OrdenesGrid estado={estadoInitial} />
+        <Suspense
+          key={`${estadoInitial}-${page}`}
+          fallback={<OrdenesListSkeleton />}
+        >
+          <OrdenesGrid
+            estado={estadoInitial}
+            page={page}
+            pageSize={pageSize}
+          />
         </Suspense>
       </div>
     </div>

--- a/src/components/produccion/OrdenProduccionCard.tsx
+++ b/src/components/produccion/OrdenProduccionCard.tsx
@@ -41,6 +41,12 @@ export default function OrdenProduccionCard({
           color: 'bg-purple-500',
           style: 'border-purple-400 bg-purple-50 ring-2 ring-purple-300',
         }
+      case 'RECHAZADA':
+        return {
+          text: 'Rechazada',
+          color: 'bg-red-500',
+          style: 'border-red-400 bg-red-50 ring-2 ring-red-300',
+        }
       default:
         return {
           text: 'Pendiente',

--- a/src/components/produccion/OrdenProduccionDetails.tsx
+++ b/src/components/produccion/OrdenProduccionDetails.tsx
@@ -10,12 +10,15 @@ import {
   User as UserIcon,
   Tag,
   Upload,
+  AlertCircle,
+  Info,
 } from 'lucide-react'
 import type { OrdenProduccion } from '@/types'
 import { Button } from '@/components/ui/Button'
 import { Card, CardContent } from '@/components/ui/Card'
 import { useState } from 'react'
 import { formatDateOnly } from '@/lib/utils'
+import MedicionesVisitaModal from '../coordinacion/orden_produccion/MedicionesVisitaModal'
 
 interface OrdenProduccionDetailsProps {
   orden: OrdenProduccion
@@ -30,6 +33,7 @@ const getEstadoBadge = (estado: OrdenProduccion['estado']) => {
     APROBADA: 'bg-blue-100 text-blue-800',
     'EN PRODUCCION': 'bg-yellow-100 text-yellow-800',
     FINALIZADA: 'bg-green-100 text-green-800',
+    RECHAZADA: 'bg-red-100 text-red-800',
   }
   return badges[estado] || 'bg-gray-100 text-gray-800'
 }
@@ -41,6 +45,7 @@ export default function OrdenProduccionDetails({
   onResubirOrden,
 }: OrdenProduccionDetailsProps) {
   const [pdfLoading, setPdfLoading] = useState(true)
+  const [isMedicionesModalOpen, setIsMedicionesModalOpen] = useState(false)
 
   const cliente = orden.obra?.cliente
   const nombreCliente =
@@ -63,6 +68,35 @@ export default function OrdenProduccionDetails({
   return (
     <Card className="mx-auto w-full max-w-7xl border-gray-200 bg-white shadow-lg lg:max-w-[95%]">
       <CardContent className="flex flex-col gap-6 p-6 lg:gap-8 lg:p-10">
+        {/* Banner de Rechazo */}
+        {orden.estado === 'RECHAZADA' && (
+          <div className="rounded-2xl border-2 border-red-200 bg-red-50 p-6 shadow-sm">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <div className="rounded-xl bg-red-100 p-3 h-fit">
+                <AlertCircle className="h-8 w-8 text-red-600" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-lg font-bold text-red-900">Orden Rechazada por Coordinación</h3>
+                <p className="mt-1 text-red-800 font-medium leading-relaxed">
+                  Motivo: {orden.motivo_rechazo || 'No se especificó motivo.'}
+                </p>
+                <p className="mt-2 text-sm text-red-600 italic">
+                  Por favor, revise las mediciones de la visita y corrija el archivo PDF antes de resubirlo.
+                </p>
+              </div>
+              {orden.visita?.estado === 'COMPLETADA' && (
+                <Button
+                  onClick={() => setIsMedicionesModalOpen(true)}
+                  className="bg-white border-2 border-red-200 text-red-700 hover:bg-red-100 shadow-none px-6"
+                >
+                  <Info className="mr-2 h-5 w-5" />
+                  Ver Mediciones
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div className="flex items-start justify-between space-x-4 border-b pb-6">
           <div className="flex-1">
@@ -226,13 +260,17 @@ export default function OrdenProduccionDetails({
                       <span>Finalizar Producción</span>
                     </Button>
                   )}
-                  {onResubirOrden && orden.estado === 'PENDIENTE' && (
+                  {(onResubirOrden && (orden.estado === 'PENDIENTE' || orden.estado === 'RECHAZADA')) && (
                     <Button
                       onClick={onResubirOrden}
-                      className="w-full cursor-pointer bg-purple-500 py-4 text-base text-white transition-colors hover:bg-purple-600 lg:py-5 lg:text-lg"
+                      className={`w-full cursor-pointer py-4 text-base text-white transition-colors lg:py-5 lg:text-lg ${
+                        orden.estado === 'RECHAZADA' 
+                          ? 'bg-red-600 hover:bg-red-700 shadow-red-100' 
+                          : 'bg-purple-500 hover:bg-purple-600'
+                      }`}
                     >
                       <Upload className="mr-2 h-5 w-5 lg:h-6 lg:w-6" />
-                      <span>Resubir OP</span>
+                      <span>{orden.estado === 'RECHAZADA' ? 'Corregir y Resubir OP' : 'Resubir OP'}</span>
                     </Button>
                   )}
                 </div>
@@ -240,6 +278,14 @@ export default function OrdenProduccionDetails({
             )}
           </div>
         </div>
+        
+        {orden.visita && (
+          <MedicionesVisitaModal
+            isOpen={isMedicionesModalOpen}
+            onClose={() => setIsMedicionesModalOpen(false)}
+            visita={orden.visita}
+          />
+        )}
       </CardContent>
     </Card>
   )

--- a/src/components/produccion/ProduccionClient.tsx
+++ b/src/components/produccion/ProduccionClient.tsx
@@ -71,6 +71,7 @@ export default function ProduccionClient({
     ordenesPendientesCount,
     ordenesAprobadasCount,
     ordenesEnProduccionCount,
+    ordenesRechazadasCount,
     selectedOrdenSummary,
     handleTabChange,
     handleNotasTabChange,
@@ -148,6 +149,11 @@ export default function ProduccionClient({
                   count={ordenesEnProduccionCount}
                   label="En Producción"
                   color="green"
+                />
+                <StatBadge
+                  count={ordenesRechazadasCount}
+                  label="Rechazadas"
+                  color="orange"
                 />
               </>
             )}

--- a/src/components/produccion/SidebarOrdenesProduccion.tsx
+++ b/src/components/produccion/SidebarOrdenesProduccion.tsx
@@ -4,7 +4,7 @@ import { Calendar, Filter } from 'lucide-react'
 import type { OrdenProduccion, EstadoOrdenProduccion } from '@/types'
 import OrdenProduccionCard from './OrdenProduccionCard'
 
-type TabType = EstadoOrdenProduccion
+type TabType = EstadoOrdenProduccion | 'TODOS'
 
 interface SidebarOrdenesFilters {
   fechaDesde: string
@@ -132,6 +132,16 @@ export default function SidebarOrdenesProduccion({
       {/* Status Switcher */}
       <div className="border-b border-gray-50 bg-white px-4 py-3">
         <div className="flex rounded-xl bg-gray-100/80 p-1">
+          <button
+            onClick={() => onStatusChange('TODOS')}
+            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${
+              statusFilter === 'TODOS'
+                ? 'bg-white text-gray-900 shadow-sm ring-1 ring-gray-200'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            TODOS
+          </button>
           <button
             onClick={() => onStatusChange('PENDIENTE')}
             className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${

--- a/src/components/produccion/SidebarOrdenesProduccion.tsx
+++ b/src/components/produccion/SidebarOrdenesProduccion.tsx
@@ -134,7 +134,7 @@ export default function SidebarOrdenesProduccion({
         <div className="flex rounded-xl bg-gray-100/80 p-1">
           <button
             onClick={() => onStatusChange('PENDIENTE')}
-            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[10px] font-bold transition-all ${
+            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${
               statusFilter === 'PENDIENTE'
                 ? 'bg-white text-amber-600 shadow-sm ring-1 ring-gray-200'
                 : 'text-gray-500 hover:text-gray-700'
@@ -143,8 +143,18 @@ export default function SidebarOrdenesProduccion({
             PENDIENTES
           </button>
           <button
+            onClick={() => onStatusChange('RECHAZADA')}
+            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${
+              statusFilter === 'RECHAZADA'
+                ? 'bg-white text-red-600 shadow-sm ring-1 ring-gray-200'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            RECHAZADAS
+          </button>
+          <button
             onClick={() => onStatusChange('APROBADA')}
-            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[10px] font-bold transition-all ${
+            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${
               statusFilter === 'APROBADA'
                 ? 'bg-white text-orange-600 shadow-sm ring-1 ring-gray-200'
                 : 'text-gray-500 hover:text-gray-700'
@@ -154,7 +164,7 @@ export default function SidebarOrdenesProduccion({
           </button>
           <button
             onClick={() => onStatusChange('EN PRODUCCION')}
-            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[10px] font-bold transition-all ${
+            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${
               statusFilter === 'EN PRODUCCION'
                 ? 'bg-white text-blue-600 shadow-sm ring-1 ring-gray-200'
                 : 'text-gray-500 hover:text-gray-700'
@@ -164,7 +174,7 @@ export default function SidebarOrdenesProduccion({
           </button>
           <button
             onClick={() => onStatusChange('FINALIZADA')}
-            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[10px] font-bold transition-all ${
+            className={`flex flex-1 items-center justify-center gap-1 rounded-lg py-2 text-[9px] font-bold transition-all ${
               statusFilter === 'FINALIZADA'
                 ? 'bg-white text-green-600 shadow-sm ring-1 ring-gray-200'
                 : 'text-gray-500 hover:text-gray-700'

--- a/src/components/shared/EntregaDetailsModal.tsx
+++ b/src/components/shared/EntregaDetailsModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { X, Info, FileText } from 'lucide-react'
+import { X, Info } from 'lucide-react'
 import type { Entrega } from '@/types'
 import { getViaticoByDate } from '@/actions/parametros'
 import { getEntrega } from '@/actions/entregas'
@@ -122,8 +122,6 @@ export default function EntregaDetailsModal({
 
                 <EntregaRecursosPersonal
                   entrega={estaEntrega}
-                  viaticoPorDia={viaticoPorDia}
-                  totalViaticos={totalViaticos}
                 />
               </div>
 

--- a/src/components/shared/entrega-details/EntregaRecursosPersonal.tsx
+++ b/src/components/shared/entrega-details/EntregaRecursosPersonal.tsx
@@ -4,24 +4,11 @@ import { Shield, Users, Truck, Wrench } from 'lucide-react'
 import type { Entrega, Vehiculo, Maquinaria } from '@/types'
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const formatCurrency = (amount: number) => {
-  return new Intl.NumberFormat('es-AR', {
-    style: 'currency',
-    currency: 'ARS',
-  }).format(amount)
-}
-
-// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 interface EntregaRecursosPersonalProps {
   entrega: Entrega
-  viaticoPorDia: number
-  totalViaticos: number
 }
 
 // ---------------------------------------------------------------------------
@@ -30,8 +17,6 @@ interface EntregaRecursosPersonalProps {
 
 export default function EntregaRecursosPersonal({
   entrega,
-  viaticoPorDia,
-  totalViaticos,
 }: EntregaRecursosPersonalProps) {
   const encargado = entrega.entrega_empleado?.find((e) => e.rol_entrega === 'ENCARGADO')
   const acompanantes = entrega.entrega_empleado?.filter((e) => e.rol_entrega !== 'ENCARGADO')

--- a/src/components/visitador/VisitaDetailsVisitador.tsx
+++ b/src/components/visitador/VisitaDetailsVisitador.tsx
@@ -255,6 +255,51 @@ export default function VisitaDetails({
                 </div>
               )}
 
+              {/* Órdenes de Producción Vinculadas (Documentos Relacionados) */}
+              {visita.ordenes_de_produccion && visita.ordenes_de_produccion.length > 0 && (
+                <div className="space-y-3">
+                  <h5 className="px-1 text-sm font-semibold text-gray-600">
+                    Órdenes a Validar
+                  </h5>
+                  <div className="grid gap-3">
+                    {visita.ordenes_de_produccion.map((op) => (
+                      <div
+                        key={op.cod_op}
+                        className="rounded-xl border border-indigo-200 bg-indigo-50/50 p-4 shadow-sm"
+                      >
+                        <div className="flex items-center justify-between gap-4">
+                          <div className="flex items-center space-x-3">
+                            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-600">
+                              <FileText className="h-5 w-5" />
+                            </div>
+                            <div>
+                              <h4 className="text-sm font-bold text-indigo-900 uppercase">
+                                Orden #{op.cod_op}
+                              </h4>
+                              <p className="text-xs font-medium text-indigo-700/80">
+                                {op.estado}
+                              </p>
+                            </div>
+                          </div>
+                          <Button
+                            type="button"
+                            onClick={() =>
+                              handleVerDocumento(
+                                op.url,
+                                `Orden de Producción #${op.cod_op}`
+                              )
+                            }
+                            className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-indigo-700"
+                          >
+                            Ver Orden
+                          </Button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* Órdenes de Producción */}
               {visita.obra && (
                 <div className="flex flex-1 flex-col">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -50,6 +50,7 @@ export const ESTADOS_ORDEN_PRODUCCION = [
   'APROBADA',
   'EN PRODUCCION',
   'FINALIZADA',
+  'RECHAZADA',
 ] as const
 
 export const MOTIVOS_VISITA = [

--- a/src/hooks/useProduccionClient.ts
+++ b/src/hooks/useProduccionClient.ts
@@ -23,7 +23,7 @@ import { notify } from '@/lib/toast'
 
 export type MainTab = 'notas' | 'ordenes'
 export type NotasTab = EstadoNotaFabricaProduccion
-export type OrdenesTab = EstadoOrdenProduccion
+export type OrdenesTab = EstadoOrdenProduccion | 'TODOS'
 
 interface ProduccionFilters {
   fechaDesde: string
@@ -71,7 +71,7 @@ export default function useProduccionClient(
   const [activeTab, setActiveTab] = useState<MainTab>('notas')
   const [activeNotasTab, setActiveNotasTab] = useState<NotasTab>('SIN_ORDEN')
   const [activeOrdenesTab, setActiveOrdenesTab] =
-    useState<OrdenesTab>('PENDIENTE')
+    useState<OrdenesTab>('TODOS')
 
   // Sidebar state
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -113,7 +113,7 @@ export default function useProduccionClient(
     [activeNotasTab, notasFilters]
   )
   const activeOrdenesKey = useMemo(
-    () => buildCacheKey(activeOrdenesTab, ordenesFilters),
+    () => buildCacheKey(activeOrdenesTab || 'TODOS', ordenesFilters),
     [activeOrdenesTab, ordenesFilters]
   )
 
@@ -200,12 +200,13 @@ export default function useProduccionClient(
       setLoadingOrdenes(true)
       setErrorOrdenes(null)
       try {
-        const ordenes = await getOrdenesProduccionPorEstadoYFechas({
-          estado: activeOrdenesTab,
+        const response = await getOrdenesProduccionPorEstadoYFechas({
+          estado: activeOrdenesTab === 'TODOS' ? undefined : activeOrdenesTab,
           ...getRequestFilters(ordenesFilters),
+          pageSize: 1000, // Fetch many for the internal cache/counts
         })
         if (!cancelled) {
-          setOrdenesCache((prev) => ({ ...prev, [activeOrdenesKey]: ordenes }))
+          setOrdenesCache((prev) => ({ ...prev, [activeOrdenesKey]: response.data }))
         }
       } catch {
         if (!cancelled)

--- a/src/hooks/useProduccionClient.ts
+++ b/src/hooks/useProduccionClient.ts
@@ -159,6 +159,8 @@ export default function useProduccionClient(
     ordenesCache[buildCacheKey('APROBADA', EMPTY_FILTERS)]?.length ?? 0
   const ordenesEnProduccionCount =
     ordenesCache[buildCacheKey('EN PRODUCCION', EMPTY_FILTERS)]?.length ?? 0
+  const ordenesRechazadasCount =
+    ordenesCache[buildCacheKey('RECHAZADA', EMPTY_FILTERS)]?.length ?? 0
 
   // Data Fetching: Notas
   useEffect(() => {
@@ -382,6 +384,7 @@ export default function useProduccionClient(
     ordenesPendientesCount,
     ordenesAprobadasCount,
     ordenesEnProduccionCount,
+    ordenesRechazadasCount,
     selectedOrdenSummary,
     handleTabChange,
     handleNotasTabChange,

--- a/src/hooks/useVisitaForm.ts
+++ b/src/hooks/useVisitaForm.ts
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
-import type { Visita, Obra, Empleado, Localidad, Provincia } from '@/types'
+import type { Visita, Obra, Empleado, Localidad, Provincia, OrdenProduccion } from '@/types'
+import { getObra } from '@/actions/obras'
 import { createVisitaFromForm, updateVisitaFromForm } from '@/actions/visitas'
 import { getActualViatico, getViaticoByDate } from '@/actions/parametros'
 import { notify } from '@/lib/toast'
@@ -62,6 +63,10 @@ export interface UseVisitaFormReturn {
   isPending: boolean
   error: string | null
   setError: (v: string | null) => void
+  selectedOps: number[]
+  setSelectedOps: (v: number[] | ((prev: number[]) => number[])) => void
+  eligibleOps: OrdenProduccion[]
+  isLoadingOps: boolean
   viaticoPorDia: number
   totalViaticos: number
   getEmpleadoNombre: (cuil: string) => string
@@ -120,6 +125,9 @@ export default function useVisitaForm({
   const [localidades, setLocalidades] = useState<Localidad[]>([])
   const [loadingLocalidades, setLoadingLocalidades] = useState(false)
   const [viaticoPorDia, setViaticoPorDia] = useState(0)
+  const [selectedOps, setSelectedOps] = useState<number[]>([])
+  const [eligibleOps, setEligibleOps] = useState<OrdenProduccion[]>([])
+  const [isLoadingOps, setIsLoadingOps] = useState(false)
 
   // Fetch viatico rate
   useEffect(() => {
@@ -134,6 +142,78 @@ export default function useVisitaForm({
     }
     fetchViatico()
   }, [visitaEditar])
+
+  // Handle cod_op and cod_obra from URL searchParams
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search)
+      const codOp = params.get('cod_op')
+      const codObra = params.get('cod_obra')
+
+      if (codOp) {
+        setSelectedOps([Number(codOp)])
+        setIsVisitaInicial(false)
+      }
+
+      if (codObra && !formData.obraId) {
+        const fetchObra = async () => {
+          const obra = await getObra(Number(codObra))
+          if (obra) {
+            setFormData((prev) => ({
+              ...prev,
+              obraId: obra.cod_obra,
+              direccion: obra.direccion,
+              localidad: obra.localidad?.nombre_localidad ?? '',
+            }))
+            setIsVisitaInicial(false)
+          }
+        }
+        fetchObra()
+      }
+    }
+  }, [])
+
+  // Fetch eligible OPs when obraId changes
+  useEffect(() => {
+    async function fetchOps() {
+      if (!formData.obraId) {
+        setEligibleOps([])
+        return
+      }
+
+      setIsLoadingOps(true)
+      try {
+        const { getOrdenesProduccionBusquedaAvanzada } = await import('@/actions/ordenes')
+        const ops = await getOrdenesProduccionBusquedaAvanzada({
+          cod_obra: formData.obraId,
+          estado: 'PENDIENTE',
+        })
+        
+        // Filtrar las OPs elegibles según reglas de negocio
+        const filteredOps = ops.filter((op) => {
+          // 1. Solo OPs en estado PENDIENTE (excluye EN PRODUCCION, TERMINADA, APROBADA)
+          if (op.estado !== 'PENDIENTE') return false
+
+          // 2. Excluir si ya tiene una visita vinculada que no esté CANCELADA
+          const tieneVisitaActiva = op.visita && op.visita.estado !== 'CANCELADA'
+          
+          // Nota: Si la OP es la que viene por URL (selectedOps), la dejamos visible
+          if (tieneVisitaActiva && !selectedOps.includes(op.cod_op)) {
+            return false
+          }
+
+          return true
+        })
+
+        setEligibleOps(filteredOps)
+      } catch (err) {
+        console.error('Error fetching eligible OPs:', err)
+      } finally {
+        setIsLoadingOps(false)
+      }
+    }
+    fetchOps()
+  }, [formData.obraId])
 
   const totalViaticos = (formData.dias_viatico || 0) * ( (visitadorPrincipal ? 1 : 0) + selectedAcompanantes.length) * viaticoPorDia
 
@@ -311,6 +391,10 @@ export default function useVisitaForm({
       if (formData.obraId) {
         formDataObj.append('obraId', formData.obraId.toString())
       }
+      
+      if (selectedOps.length > 0) {
+        formDataObj.append('cod_ops', JSON.stringify(selectedOps))
+      }
 
       const action = visitaEditar ? updateVisitaFromForm : createVisitaFromForm
       try {
@@ -359,6 +443,10 @@ export default function useVisitaForm({
     isPending,
     error,
     setError,
+    selectedOps,
+    setSelectedOps,
+    eligibleOps,
+    isLoadingOps,
     getEmpleadoNombre,
     handleLoadLocalidades,
     handleSubmit,

--- a/src/hooks/useVisitaForm.ts
+++ b/src/hooks/useVisitaForm.ts
@@ -184,19 +184,19 @@ export default function useVisitaForm({
       setIsLoadingOps(true)
       try {
         const { getOrdenesProduccionBusquedaAvanzada } = await import('@/actions/ordenes')
-        const ops = await getOrdenesProduccionBusquedaAvanzada({
+        const response = await getOrdenesProduccionBusquedaAvanzada({
           cod_obra: formData.obraId,
           estado: 'PENDIENTE',
-        })
-        
+        }, 1, 1000)
+
         // Filtrar las OPs elegibles según reglas de negocio
-        const filteredOps = ops.filter((op) => {
+        const filteredOps = response.data.filter((op: OrdenProduccion) => {
           // 1. Solo OPs en estado PENDIENTE (excluye EN PRODUCCION, TERMINADA, APROBADA)
           if (op.estado !== 'PENDIENTE') return false
 
           // 2. Excluir si ya tiene una visita vinculada que no esté CANCELADA
           const tieneVisitaActiva = op.visita && op.visita.estado !== 'CANCELADA'
-          
+
           // Nota: Si la OP es la que viene por URL (selectedOps), la dejamos visible
           if (tieneVisitaActiva && !selectedOps.includes(op.cod_op)) {
             return false
@@ -215,7 +215,7 @@ export default function useVisitaForm({
     fetchOps()
   }, [formData.obraId, selectedOps])
 
-  const totalViaticos = (formData.dias_viatico || 0) * ( (visitadorPrincipal ? 1 : 0) + selectedAcompanantes.length) * viaticoPorDia
+  const totalViaticos = (formData.dias_viatico || 0) * ((visitadorPrincipal ? 1 : 0) + selectedAcompanantes.length) * viaticoPorDia
 
   // Sync motivo_visita with isVisitaInicial toggle
   useEffect(() => {
@@ -391,7 +391,7 @@ export default function useVisitaForm({
       if (formData.obraId) {
         formDataObj.append('obraId', formData.obraId.toString())
       }
-      
+
       if (selectedOps.length > 0) {
         formDataObj.append('cod_ops', JSON.stringify(selectedOps))
       }

--- a/src/hooks/useVisitaForm.ts
+++ b/src/hooks/useVisitaForm.ts
@@ -171,7 +171,7 @@ export default function useVisitaForm({
         fetchObra()
       }
     }
-  }, [])
+  }, [formData.obraId])
 
   // Fetch eligible OPs when obraId changes
   useEffect(() => {
@@ -213,7 +213,7 @@ export default function useVisitaForm({
       }
     }
     fetchOps()
-  }, [formData.obraId])
+  }, [formData.obraId, selectedOps])
 
   const totalViaticos = (formData.dias_viatico || 0) * ( (visitadorPrincipal ? 1 : 0) + selectedAcompanantes.length) * viaticoPorDia
 

--- a/src/types/entrega.ts
+++ b/src/types/entrega.ts
@@ -52,6 +52,7 @@ export interface OrdenProduccion {
   url: string
   public_id: string | null
   cod_visita: number | null
+  motivo_rechazo: string | null
   visita: Visita | null
   obra: Obra & { visita?: Visita[] }
 }

--- a/src/types/entrega.ts
+++ b/src/types/entrega.ts
@@ -2,6 +2,7 @@ import type { Empleado } from '@/types/auth'
 import type { Obra } from '@/types/obra'
 import type { UsoMaquinaria } from '@/types/maquinaria'
 import type { UsoVehiculoEntrega } from '@/types/vehiculo'
+import type { Visita } from '@/types/visita'
 import {
   ESTADOS_ENTREGA,
   ESTADOS_ORDEN_PRODUCCION,
@@ -50,5 +51,7 @@ export interface OrdenProduccion {
   fecha_validacion: string | null
   url: string
   public_id: string | null
-  obra: Obra & { visita?: import('./visita').Visita[] }
+  cod_visita: number | null
+  visita: Visita | null
+  obra: Obra & { visita?: Visita[] }
 }

--- a/src/types/visita.ts
+++ b/src/types/visita.ts
@@ -2,6 +2,7 @@ import type { Empleado } from '@/types/auth'
 import type { Obra } from '@/types/obra'
 import type { Localidad } from '@/types/geo'
 import type { UsoVehiculoVisita } from '@/types/vehiculo'
+import type { OrdenProduccion } from '@/types/entrega'
 import { ESTADOS_VISITA, MOTIVOS_VISITA } from '@/constants'
 
 export type MotivoVisita = (typeof MOTIVOS_VISITA)[number]
@@ -32,6 +33,7 @@ export interface Visita {
   telefono_cliente?: string
   mail_cliente?: string
   localidad?: Localidad
+  ordenes_de_produccion?: OrdenProduccion[]
 }
 
 export type VisitaFormData = {
@@ -51,4 +53,5 @@ export type VisitaFormData = {
   nombre_cliente?: string | null
   apellido_cliente?: string | null
   telefono_cliente?: string | null
+  cod_ops?: number[]
 }


### PR DESCRIPTION
### Issue Relacionada

---

### Resumen
Implementación de la experiencia de usuario para el rechazo y corrección de OPs, facilitando la comunicación técnica entre Coordinación y Producción mediante banners de feedback y acciones directas.

### Cambios Técnicos Implementados
- **Tipado y Constantes**: Se integró el estado `RECHAZADA` en `EstadoOrdenProduccion` y las constantes globales.
- **Acciones Directas en Coordinación**: 
    - Se añadió el botón "**Rechazar**" directamente en `OrdenProduccionCard` para evitar clics innecesarios.
    - Implementación de `RechazarOPModal` para la captura del motivo del rechazo.
- **Dashboard de Producción**:
    - **Nueva Pestaña**: Se añadió el filtro "Rechazadas" y el contador en el header del dashboard.
    - **Feedback Banner**: En la vista de detalles, se muestra un banner rojo con el motivo exacto del rechazo y un acceso directo a las "**Mediciones de Visita**" para facilitar la corrección.
    - **Resubida**: Lógica condicional en el botón de acción para mostrar "**Corregir y Resubir OP**" cuando el estado es rechazado.

---

### Guía para Pruebas y Revisión
1. **Coordinación**: Rechazar una OP desde la tarjeta del listado. Verificar que el modal de motivo funcione y la tarjeta cambie a color rojo.
2. **Producción**:
    - Verificar que el contador de "Rechazadas" se actualice.
    - Entrar en la pestaña "Rechazadas", abrir la orden y comprobar que el banner muestra el motivo ingresado.
    - Abrir el modal de mediciones desde el banner para verificar la integración.
    - Resubir un PDF y verificar que la orden pase nuevamente a estado "Pendiente".
