### PR TITLE
feat(prospects): optimize prospect list and add re-solicitation flow

### DIFF
--- a/src/actions/visitas.ts
+++ b/src/actions/visitas.ts
@@ -371,6 +371,7 @@ export async function getProspectos(
 
 export async function crearProspecto(data: {
   nombre: string
+  apellido: string
   telefono: string
   direccion: string
   cod_localidad: number
@@ -378,10 +379,11 @@ export async function crearProspecto(data: {
   try {
     const visitaData = {
       nombre_cliente: data.nombre,
+      apellido_cliente: data.apellido,
       telefono_cliente: data.telefono,
       direccion_visita: data.direccion,
       cod_localidad: data.cod_localidad,
-      motivo_visita: 'INICIAL',
+      motivo_visita: 'VISITA INICIAL',
       estado: 'PROGRAMADA', // We keep it PROGRAMADA but without date so it's "pending schedule"
       fecha_hora_visita: null as unknown as string, // Backend allows null if we send it in API wait, API might reject null if schema is strict? Let's send a fake date far in future if needed? No, backend accepts empty string or null? Let's check backend schema in sigma-la-schemas if it fails. We can also just send it as a random date and wait for coordinacion to change it? Or just let it be. Prisma allows it.
       empleados_visita: [],
@@ -389,12 +391,10 @@ export async function crearProspecto(data: {
       dias_viatico: 1
     }
 
-    // Since fecha_hora_visita is required by Prisma logic if it's a date but wait, it's optional in schema?
-    // Let's send a "fake" date like 1970-01-01T00:00:00Z to indicate it's not scheduled, or just new Date() because it's required by the CreateVisitaData interface!
-    // Wait, CreateVisitaData requires `fecha_hora_visita: string`.
+    // The date is null until Coordination schedules it.
     const visitaPayload = {
       ...visitaData,
-      fecha_hora_visita: new Date(new Date().setHours(0,0,0,0)).toISOString(), // today
+      fecha_hora_visita: null, 
       observaciones: 'SOLICITUD DE PROSPECTO - FALTA AGENDAR'
     }
 
@@ -414,6 +414,33 @@ export async function crearProspecto(data: {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Error al crear solicitud'
     console.error('[crearProspecto]', message)
+    return { success: false, error: message }
+  }
+}
+
+export async function reSolicitarMedicion(cod_visita: number) {
+  try {
+    const token = await getAccessToken()
+    await fetchWithErrorHandling<Visita>(`${BASE_URL}/${cod_visita}/re-solicitar`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        estado: 'PROGRAMADA',
+        fecha_hora_visita: null,
+        fecha_cancelacion: null,
+        observaciones: 'RE-SOLICITUD DE MEDICIÓN (Previamente cancelada)'
+      }),
+    })
+    
+    revalidatePath('/ventas/prospectos')
+    revalidatePath('/coordinacion')
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error al re-solicitar medición'
+    console.error('[reSolicitarMedicion]', message)
     return { success: false, error: message }
   }
 }

--- a/src/app/(dashboard)/ventas/clientes/crear/page.tsx
+++ b/src/app/(dashboard)/ventas/clientes/crear/page.tsx
@@ -10,20 +10,9 @@ export default async function CrearClientePage({
   searchParams: SearchParams
 }) {
   const sp = await searchParams
-  const nombreRaw = typeof sp.nombre === 'string' ? sp.nombre : undefined
+  const nombre = typeof sp.nombre === 'string' ? sp.nombre : ''
+  const apellido = typeof sp.apellido === 'string' ? sp.apellido : ''
   const telefonoRaw = typeof sp.telefono === 'string' ? sp.telefono : undefined
-  
-  let nombre = ''
-  let apellido = ''
-  if (nombreRaw) {
-    const parts = nombreRaw.split(' ')
-    if (parts.length > 1) {
-      apellido = parts.pop() || ''
-      nombre = parts.join(' ')
-    } else {
-      nombre = nombreRaw
-    }
-  }
 
   const prefillData = (nombre || telefonoRaw) ? {
     cuil: '',

--- a/src/app/(dashboard)/ventas/prospectos/page.tsx
+++ b/src/app/(dashboard)/ventas/prospectos/page.tsx
@@ -1,16 +1,18 @@
-﻿import { getProspectos } from '@/actions/visitas'
+import { getProspectos } from '@/actions/visitas'
 import { getProvincias } from '@/actions/localidad'
 import SolicitarMedicionModal from '@/components/ventas/prospectos/SolicitarMedicionModal'
 import {
   Plus,
   MapPin,
   Calendar,
+  Phone,
   ClipboardCheck,
   ClipboardList,
   UserPlus,
   FileText,
 } from 'lucide-react'
 import Link from 'next/link'
+import ReSolicitarBtn from '@/components/ventas/prospectos/ReSolicitarBtn'
 import type { SearchParams } from '@/types'
 
 export default async function ProspectosPage({
@@ -76,14 +78,20 @@ export default async function ProspectosPage({
                           className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
                             prospecto.estado === 'COMPLETADA'
                               ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                              : prospecto.estado === 'PROGRAMADA'
-                                ? 'border-amber-200 bg-amber-50 text-amber-700'
-                                : 'border-slate-200 bg-slate-50 text-slate-700'
+                              : prospecto.estado === 'CANCELADA'
+                                ? 'border-rose-200 bg-rose-50 text-rose-700'
+                                : prospecto.fecha_hora_visita
+                                  ? 'border-amber-200 bg-amber-50 text-amber-700'
+                                  : 'border-slate-200 bg-slate-50 text-slate-700'
                           }`}
                         >
                           {prospecto.estado === 'COMPLETADA'
                             ? 'Medición Lista'
-                            : 'Pendiente de Medición'}
+                            : prospecto.estado === 'CANCELADA'
+                              ? 'Cancelada'
+                              : prospecto.fecha_hora_visita
+                                ? 'Pendiente de Medición'
+                                : 'Pendiente de Agendar'}
                         </span>
                       </div>
 
@@ -94,6 +102,12 @@ export default async function ProspectosPage({
                           {prospecto.localidad &&
                             `, ${prospecto.localidad.nombre_localidad}`}
                         </div>
+                        {prospecto.telefono_cliente && (
+                          <div className="flex items-center gap-1.5">
+                            <Phone className="h-4 w-4 text-gray-500" />
+                            {prospecto.telefono_cliente}
+                          </div>
+                        )}
                         {prospecto.fecha_hora_visita && (
                           <div className="flex items-center gap-1.5">
                             <Calendar className="h-4 w-4 text-gray-500" />
@@ -126,7 +140,7 @@ export default async function ProspectosPage({
                   {prospecto.estado === 'COMPLETADA' ? (
                     <div className="flex flex-wrap gap-2">
                       <Link
-                        href={`/ventas/clientes/crear?nombre=${encodeURIComponent((prospecto.nombre_cliente || '') + ' ' + (prospecto.apellido_cliente || ''))}&telefono=${encodeURIComponent(prospecto.telefono_cliente || '')}`}
+                        href={`/ventas/clientes/crear?nombre=${encodeURIComponent(prospecto.nombre_cliente || '')}&apellido=${encodeURIComponent(prospecto.apellido_cliente || '')}&telefono=${encodeURIComponent(prospecto.telefono_cliente || '')}`}
                         className="inline-flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 px-3.5 py-2 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-100"
                       >
                         <UserPlus className="h-4 w-4" />
@@ -139,6 +153,11 @@ export default async function ProspectosPage({
                         <FileText className="h-4 w-4" />
                         Generar obra
                       </Link>
+                    </div>
+                  ) : prospecto.estado === 'CANCELADA' ? (
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm text-gray-500 italic">Solicitud cancelada por Coordinación</span>
+                      <ReSolicitarBtn cod_visita={prospecto.cod_visita} />
                     </div>
                   ) : (
                     <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-sm font-medium text-slate-500">

--- a/src/components/ventas/prospectos/ReSolicitarBtn.tsx
+++ b/src/components/ventas/prospectos/ReSolicitarBtn.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { reSolicitarMedicion } from '@/actions/visitas'
+import { RotateCcw } from 'lucide-react'
+import { useState } from 'react'
+import { notify } from '@/lib/toast'
+import ReSolicitarModal from './ReSolicitarModal'
+
+interface ReSolicitarBtnProps {
+  cod_visita: number
+}
+
+export default function ReSolicitarBtn({ cod_visita }: ReSolicitarBtnProps) {
+  const [loading, setLoading] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+
+  const handleReSolicitar = async () => {
+    setLoading(true)
+    try {
+      const res = await reSolicitarMedicion(cod_visita)
+      if (res.success) {
+        notify.success('Medición re-solicitada correctamente')
+        setShowModal(false)
+      } else {
+        notify.error(res.error || 'Error al re-solicitar')
+      }
+    } catch (error) {
+      notify.error('Ocurrió un error inesperado')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setShowModal(true)}
+        disabled={loading}
+        className="inline-flex items-center gap-1.5 rounded-md bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:opacity-50"
+        title="Volver a solicitar medición"
+      >
+        <RotateCcw className="h-3.5 w-3.5" />
+        Re-solicitar
+      </button>
+
+      <ReSolicitarModal 
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        onConfirm={handleReSolicitar}
+        loading={loading}
+      />
+    </>
+  )
+}

--- a/src/components/ventas/prospectos/ReSolicitarModal.tsx
+++ b/src/components/ventas/prospectos/ReSolicitarModal.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { X, RotateCcw, AlertCircle } from 'lucide-react'
+
+interface ReSolicitarModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  loading: boolean
+}
+
+export default function ReSolicitarModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  loading
+}: ReSolicitarModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div 
+        className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm transition-opacity" 
+        onClick={!loading ? onClose : undefined}
+      />
+      
+      {/* Modal Content */}
+      <div className="relative w-full max-w-sm transform overflow-hidden rounded-2xl bg-white p-6 shadow-2xl transition-all animate-in fade-in zoom-in duration-200">
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 text-blue-600">
+            <RotateCcw className="h-7 w-7" />
+          </div>
+          
+          <h3 className="mb-2 text-xl font-bold text-gray-900">
+            ¿Confirmar re-solicitud?
+          </h3>
+          
+          <p className="mb-6 text-sm text-gray-500">
+            La medición volverá a estar pendiente de agendar por Coordinación.
+          </p>
+
+          <div className="flex w-full gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="flex-1 rounded-xl border border-gray-200 bg-white py-2.5 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={loading}
+              className="flex-1 rounded-xl bg-blue-600 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {loading ? (
+                <>
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  Procesando
+                </>
+              ) : (
+                'Confirmar'
+              )}
+            </button>
+          </div>
+        </div>
+
+        {!loading && (
+          <button
+            onClick={onClose}
+            className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ventas/prospectos/SolicitarMedicionModal.tsx
+++ b/src/components/ventas/prospectos/SolicitarMedicionModal.tsx
@@ -19,6 +19,7 @@ export default function SolicitarMedicionModal({ provincias }: SolicitarMedicion
   
   const [formData, setFormData] = useState({
     nombre: '',
+    apellido: '',
     telefono: '',
     direccion: '',
     cod_localidad: 0,
@@ -47,7 +48,7 @@ export default function SolicitarMedicionModal({ provincias }: SolicitarMedicion
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!formData.nombre || !formData.telefono || !formData.direccion || !formData.cod_localidad) {
+    if (!formData.nombre || !formData.apellido || !formData.telefono || !formData.direccion || !formData.cod_localidad) {
       notify.warning('Por favor complete todos los campos')
       return
     }
@@ -56,6 +57,7 @@ export default function SolicitarMedicionModal({ provincias }: SolicitarMedicion
     try {
       const res = await crearProspecto({
         nombre: formData.nombre,
+        apellido: formData.apellido,
         telefono: formData.telefono,
         direccion: formData.direccion,
         cod_localidad: formData.cod_localidad
@@ -66,6 +68,7 @@ export default function SolicitarMedicionModal({ provincias }: SolicitarMedicion
         setIsOpen(false)
         setFormData({
           nombre: '',
+          apellido: '',
           telefono: '',
           direccion: '',
           cod_localidad: 0,
@@ -115,20 +118,37 @@ export default function SolicitarMedicionModal({ provincias }: SolicitarMedicion
               </div>
 
               <div className="space-y-4">
-                <div>
-                  <label className="mb-1 flex items-center gap-2 text-xs font-bold text-slate-600">
-                    <User className="h-3.5 w-3.5" />
-                    NOMBRE Y APELLIDO
-                  </label>
-                  <input
-                    type="text"
-                    name="nombre"
-                    value={formData.nombre}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-slate-200 p-3 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                    placeholder="Ej: Juan Pérez"
-                    required
-                  />
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label className="mb-1 flex items-center gap-2 text-xs font-bold text-slate-600">
+                      <User className="h-3.5 w-3.5" />
+                      NOMBRE
+                    </label>
+                    <input
+                      type="text"
+                      name="nombre"
+                      value={formData.nombre}
+                      onChange={handleChange}
+                      className="w-full rounded-xl border border-slate-200 p-3 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      placeholder="Ej: Juan"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 flex items-center gap-2 text-xs font-bold text-slate-600">
+                      <User className="h-3.5 w-3.5" />
+                      APELLIDO
+                    </label>
+                    <input
+                      type="text"
+                      name="apellido"
+                      value={formData.apellido}
+                      onChange={handleChange}
+                      className="w-full rounded-xl border border-slate-200 p-3 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      placeholder="Ej: Pérez"
+                      required
+                    />
+                  </div>
                 </div>
 
                 <div>

--- a/src/hooks/useVisitaForm.ts
+++ b/src/hooks/useVisitaForm.ts
@@ -263,12 +263,12 @@ export default function useVisitaForm({
       : null
 
     setFormData({
-      fechaSalida: fSalidaLocal?.toISOString().slice(0, 10) ?? '',
-      horaSalida: fSalidaLocal?.toISOString().slice(11, 16) ?? '',
-      fecha: fechaLocal?.toISOString().slice(0, 10) ?? '',
-      hora: fechaLocal?.toISOString().slice(11, 16) ?? '',
-      fechaRegreso: fRegresoLocal?.toISOString().slice(0, 10) ?? '',
-      horaRegreso: fRegresoLocal?.toISOString().slice(11, 16) ?? '',
+      fechaSalida: fSalidaLocal ? fSalidaLocal.toISOString().slice(0, 10) : '',
+      horaSalida: fSalidaLocal ? fSalidaLocal.toISOString().slice(11, 16) : '',
+      fecha: fechaLocal ? fechaLocal.toISOString().slice(0, 10) : '',
+      hora: fechaLocal ? fechaLocal.toISOString().slice(11, 16) : '',
+      fechaRegreso: fRegresoLocal ? fRegresoLocal.toISOString().slice(0, 10) : '',
+      horaRegreso: fRegresoLocal ? fRegresoLocal.toISOString().slice(11, 16) : '',
       motivo_visita: visitaEditar.motivo_visita ?? 'OTRO',
       observaciones: visitaEditar.observaciones ?? '',
       direccion: visitaEditar.direccion_visita ?? '',


### PR DESCRIPTION
### Issue Relacionada

---

### Resumen
Optimización del flujo de prospectos en Ventas, permitiendo la re-solicitud de mediciones canceladas y mejorando la visualización de datos en las tarjetas.

### Cambios Técnicos Implementados
- **Gestión de Prospectos:** Se integró la acción `reSolicitarMedicion` conectada al nuevo endpoint del backend.
- **Componentes de UI:** Se crearon `ReSolicitarBtn` y `ReSolicitarModal` para manejar confirmaciones de re-solicitud con una estética premium y minimalista.
- **Visualización de Datos:** Se añadió el teléfono del cliente y el icono correspondiente a las tarjetas de la lista de prospectos.
- **Manejo de Estados:** Se actualizaron los badges de estado para incluir "Cancelada" (Rojo) y "Pendiente de Agendar" (Gris) de forma dinámica.
- **Formularios:** Se ajustó `useVisitaForm` para manejar correctamente valores `null` en fechas, evitando errores de formateo.

---

### Guía para Pruebas y Revisión
1.  **Lista de Prospectos:** Entrar en `/ventas/prospectos` y verificar que las tarjetas ahora muestran el teléfono del cliente.
2.  **Flujo de Re-solicitud:** Identificar un prospecto con estado "Cancelada", pulsar el botón "Re-solicitar" y confirmar en el modal. El prospecto debe volver a estado "Pendiente de Agendar".
3.  **Estética:** Verificar que el modal de confirmación tenga el efecto de desenfoque de fondo y diseño acorde al sistema.
