### PR TITLE
feat: support SIN AGENDAR state and null dates for prospects

### DIFF
--- a/src/actions/visitas.ts
+++ b/src/actions/visitas.ts
@@ -384,8 +384,8 @@ export async function crearProspecto(data: {
       direccion_visita: data.direccion,
       cod_localidad: data.cod_localidad,
       motivo_visita: 'VISITA INICIAL',
-      estado: 'PROGRAMADA', // We keep it PROGRAMADA but without date so it's "pending schedule"
-      fecha_hora_visita: null as unknown as string, // Backend allows null if we send it in API wait, API might reject null if schema is strict? Let's send a fake date far in future if needed? No, backend accepts empty string or null? Let's check backend schema in sigma-la-schemas if it fails. We can also just send it as a random date and wait for coordinacion to change it? Or just let it be. Prisma allows it.
+      estado: 'SIN AGENDAR',
+      fecha_hora_visita: null as unknown as string,
       empleados_visita: [],
       vehiculo: '',
       dias_viatico: 1
@@ -428,7 +428,7 @@ export async function reSolicitarMedicion(cod_visita: number) {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        estado: 'PROGRAMADA',
+        estado: 'SIN AGENDAR',
         fecha_hora_visita: null,
         fecha_cancelacion: null,
         observaciones: 'RE-SOLICITUD DE MEDICIÓN (Previamente cancelada)'

--- a/src/app/(dashboard)/coordinacion/prospectos/page.tsx
+++ b/src/app/(dashboard)/coordinacion/prospectos/page.tsx
@@ -1,4 +1,4 @@
-﻿import { getProspectos } from '@/actions/visitas'
+import { getProspectos } from '@/actions/visitas'
 import {
   ClipboardCheck,
   MapPin,
@@ -16,8 +16,8 @@ export default async function CoordinacionProspectosPage({
   const sp = await searchParams
   const page = Number(typeof sp.page === 'string' ? sp.page : sp.page?.[0]) || 1
 
-  // Get PROGRAMADA (pending measurement assignment) prospectos
-  const prospectosRes = await getProspectos('PROGRAMADA', page, 25)
+  // Get SIN AGENDAR (pending measurement assignment) prospectos
+  const prospectosRes = await getProspectos('SIN AGENDAR', page, 25)
   const prospectos = prospectosRes.data
 
   return (

--- a/src/app/(dashboard)/ventas/prospectos/page.tsx
+++ b/src/app/(dashboard)/ventas/prospectos/page.tsx
@@ -80,21 +80,21 @@ export default async function ProspectosPage({
                               ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
                               : prospecto.estado === 'CANCELADA'
                                 ? 'border-rose-200 bg-rose-50 text-rose-700'
-                                : prospecto.fecha_hora_visita
-                                  ? 'border-amber-200 bg-amber-50 text-amber-700'
-                                  : 'border-slate-200 bg-slate-50 text-slate-700'
+                                : prospecto.estado === 'SIN AGENDAR' || !prospecto.fecha_hora_visita || new Date(prospecto.fecha_hora_visita).getFullYear() <= 1970
+                                  ? 'border-slate-200 bg-slate-50 text-slate-700'
+                                  : 'border-amber-200 bg-amber-50 text-amber-700'
                           }`}
                         >
                           {prospecto.estado === 'COMPLETADA'
                             ? 'Medición Lista'
                             : prospecto.estado === 'CANCELADA'
                               ? 'Cancelada'
-                              : prospecto.fecha_hora_visita
-                                ? 'Pendiente de Medición'
-                                : 'Pendiente de Agendar'}
+                              : prospecto.estado === 'SIN AGENDAR' || !prospecto.fecha_hora_visita || new Date(prospecto.fecha_hora_visita).getFullYear() <= 1970
+                                ? 'Pendiente de Agendar'
+                                : 'Pendiente de Medición'}
                         </span>
                       </div>
-
+ 
                       <div className="mt-2 flex flex-col gap-2 text-sm text-gray-600 sm:flex-row sm:items-center sm:gap-6">
                         <div className="flex items-center gap-1.5">
                           <MapPin className="h-4 w-4 text-gray-500" />
@@ -108,7 +108,7 @@ export default async function ProspectosPage({
                             {prospecto.telefono_cliente}
                           </div>
                         )}
-                        {prospecto.fecha_hora_visita && (
+                        {prospecto.fecha_hora_visita && new Date(prospecto.fecha_hora_visita).getFullYear() > 1970 && (
                           <div className="flex items-center gap-1.5">
                             <Calendar className="h-4 w-4 text-gray-500" />
                             Agendado para:{' '}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -63,6 +63,7 @@ export const MOTIVOS_VISITA = [
 
 export const ESTADOS_VISITA = [
   'PENDIENTE',
+  'SIN AGENDAR',
   'PROGRAMADA',
   'EN CURSO',
   'CANCELADA',
@@ -118,6 +119,7 @@ export const COLORES_ESTADO_OBRA: Record<(typeof ESTADOS_OBRA)[number], string> 
 
 export const COLORES_ESTADO_VISITA: Record<(typeof ESTADOS_VISITA)[number], string> = {
   PENDIENTE: '#94a3b8',
+  'SIN AGENDAR': '#64748b',
   PROGRAMADA: '#3b82f6',
   'EN CURSO': '#f59e0b',
   CANCELADA: '#ef4444',


### PR DESCRIPTION
# Visualización de Prospectos con Estado "SIN AGENDAR"

## Cambios realizados
- **Soporte de Fechas Nulas**: Actualización de vistas en Ventas y Coordinación para renderizar visitas sin fecha asignada.
- **Constantes de Estado**: Integración de colores y etiquetas para el nuevo estado `SIN AGENDAR`.
- **Limpieza de UI**: Eliminación de fechas "placeholder" (1970) en favor de estados de agenda reales.

## Problemas resueltos
- Visualización de fechas incorrectas (1970/12/31) en la tabla de prospectos.
- Desfase visual entre estados del Backend y Frontend.
